### PR TITLE
Fix: Jwt issuing way & Validate way

### DIFF
--- a/server/src/auth/auth.controller.ts
+++ b/server/src/auth/auth.controller.ts
@@ -13,6 +13,7 @@ import { AdminSignUpInputDto } from 'src/database/dtos/admin/admin.inbound-port.
 import { FindOneAdminExceptPasswordDto } from 'src/database/dtos/admin/admin.outbound-port.dto';
 import { ADMIN_GRADE } from 'src/database/values/admin-grade.value';
 import { JwtMasterAdminGuard } from './guards/jwt-master-admin.guard';
+import { JwtAdminGuard } from './guards/jwt-admin.guard';
 
 @Controller('api/v1/auth')
 export class AuthController {

--- a/server/src/auth/auth.module.ts
+++ b/server/src/auth/auth.module.ts
@@ -8,6 +8,7 @@ import { AdminRepository } from 'src/database/repositories/admin.repository';
 import { JwtModule } from '@nestjs/jwt';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { JwtAdminStrategy } from './strategies/jwt-admin.strategy';
+import { JwtMasterAdminStratety } from './strategies/jwt-master-admin.strategy';
 
 @Module({
   imports: [
@@ -32,6 +33,7 @@ import { JwtAdminStrategy } from './strategies/jwt-admin.strategy';
     AuthService,
     AdminStrategy,
     JwtAdminStrategy,
+    JwtMasterAdminStratety,
   ],
 })
 export class AuthModule {}

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -3,7 +3,10 @@ import {
   ADMIN_REPOSITORY_OUTBOUND_PORT,
   AdminRepositoryOutboundPort,
 } from 'src/database/repositories/outbound-ports/admin-repository.outbound-port';
-import { AdminLogInDto } from 'src/database/dtos/auth/admin-login.dto';
+import {
+  AdminJwtDto,
+  AdminLogInDto,
+} from 'src/database/dtos/auth/admin-login.dto';
 import { JwtService } from '@nestjs/jwt';
 import { AdminSignUpInputDto } from 'src/database/dtos/admin/admin.inbound-port.dto';
 import { FindOneAdminExceptPasswordDto } from 'src/database/dtos/admin/admin.outbound-port.dto';
@@ -40,7 +43,10 @@ export class AuthService {
   }
 
   async adminSignIn(user: AdminLogInDto): Promise<{ accessToken: string }> {
-    const payload = { ...user };
+    const payload: Omit<AdminJwtDto, 'iat' | 'exp'> = {
+      type: 'admin',
+      ...user,
+    };
     return {
       accessToken: this.jwtService.sign(payload),
     };

--- a/server/src/auth/strategies/jwt-admin.strategy.ts
+++ b/server/src/auth/strategies/jwt-admin.strategy.ts
@@ -1,7 +1,8 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
+import { AdminJwtDto } from 'src/database/dtos/auth/admin-login.dto';
 
 @Injectable()
 export class JwtAdminStrategy extends PassportStrategy(Strategy, 'jwt-admin') {
@@ -13,8 +14,13 @@ export class JwtAdminStrategy extends PassportStrategy(Strategy, 'jwt-admin') {
     });
   }
 
-  async validate(payload) {
+  async validate(payload: AdminJwtDto) {
     const { iat, exp, ...user } = payload;
+
+    if (user.type !== 'admin') {
+      throw new BadRequestException('UnAuthorized');
+    }
+
     return user;
   }
 }

--- a/server/src/auth/strategies/jwt-master-admin.strategy.ts
+++ b/server/src/auth/strategies/jwt-master-admin.strategy.ts
@@ -1,7 +1,9 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
+import { AdminJwtDto } from 'src/database/dtos/auth/admin-login.dto';
+import { ADMIN_GRADE } from 'src/database/values/admin-grade.value';
 
 @Injectable()
 export class JwtMasterAdminStratety extends PassportStrategy(
@@ -16,7 +18,16 @@ export class JwtMasterAdminStratety extends PassportStrategy(
     });
   }
 
-  async validate(payload) {
+  async validate(payload: AdminJwtDto) {
     const { iat, exp, ...user } = payload;
+    if (user.type !== 'admin') {
+      throw new BadRequestException('UnAuthorized');
+    }
+
+    if (user.gradeId !== ADMIN_GRADE.master) {
+      throw new BadRequestException('UnAuthorized');
+    }
+
+    return user;
   }
 }

--- a/server/src/database/dtos/auth/admin-login.dto.ts
+++ b/server/src/database/dtos/auth/admin-login.dto.ts
@@ -1,6 +1,21 @@
 import { Admin } from '@prisma/client';
+import { UserType } from 'src/database/values/user-type.value';
 
 export type AdminLogInDto = Pick<
   Admin,
   'id' | 'email' | 'gradeId' | 'nickname'
 >;
+
+export interface AdminJwtDto extends AdminLogInDto {
+  type: UserType;
+
+  /**
+   * @type int
+   */
+  iat: number;
+
+  /**
+   * @type int
+   */
+  exp: number;
+}


### PR DESCRIPTION
## 개요

- Jwt에 type 속성을 추가하여, 어드민인지 일반 유저인지 확인 가능하다.
- JwtMasterAdminStrategy를 추가하여 마스터 어드민인지 확인 가능하다.

## ✅ 작업 내용

- JwtMasterAdminStrategy 작성
- JwtMasterAdminGuard 작성
- AdminJwtDto 작성

## 🔨 변경 로직

- Jwt 발급시, type속성을 추가 (adminSignIn in AuthService)
- JwtAdminStrategy에서 type : admin 인 경우 체크하도록 수정
- AuthModule에 JwtMasterAdminStrategy 추가

## 🧨 관련 이슈

- #8 