### PR TITLE
Fix : dto and type about prisma

### DIFF
--- a/server/.eslintrc.js
+++ b/server/.eslintrc.js
@@ -2,7 +2,7 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   parserOptions: {
     project: 'tsconfig.json',
-    tsconfigRootDir : __dirname, 
+    tsconfigRootDir: __dirname,
     sourceType: 'module',
   },
   plugins: ['@typescript-eslint/eslint-plugin'],
@@ -21,5 +21,6 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-namespace': 'off',
   },
 };

--- a/server/src/database/dtos/admin/admin-options.dto.ts
+++ b/server/src/database/dtos/admin/admin-options.dto.ts
@@ -1,5 +1,5 @@
-import { Admin } from '@prisma/client';
+import { AdminEntity } from 'src/database/models/admin/admin.entity';
 
 export type AdminOptionsDto = Partial<
-  Pick<Admin, 'id' | 'email' | 'nickname' | 'gradeId'>
+  Pick<AdminEntity.Admin, 'id' | 'email' | 'nickname' | 'gradeId'>
 >;

--- a/server/src/database/dtos/admin/admin.inbound-port.dto.ts
+++ b/server/src/database/dtos/admin/admin.inbound-port.dto.ts
@@ -1,21 +1,16 @@
-import { Admin } from '@prisma/client';
-import { DateAndBigIntToString } from 'src/utils/types/date-to-string.type';
+import { AdminEntity } from 'src/database/models/admin/admin.entity';
 
-export type AdminSignUpInputDto = DateAndBigIntToString<
-  Omit<
-    Pick<
-      Admin,
-      | 'email'
-      | 'password'
-      | 'firstName'
-      | 'lastName'
-      | 'nickname'
-      | 'emailReception'
-      | 'genderId'
-      | 'gradeId'
-      | 'birth'
-    > &
-      Partial<Pick<Admin, 'middleName' | 'introduction'>>,
-    never
-  >
+export type AdminSignUpInputDto = Pick<
+  AdminEntity.Admin,
+  | 'email'
+  | 'password'
+  | 'firstName'
+  | 'lastName'
+  | 'nickname'
+  | 'emailReception'
+  | 'genderId'
+  | 'gradeId'
+  | 'birth'
+  | 'introduction'
+  | 'middleName'
 >;

--- a/server/src/database/dtos/admin/admin.outbound-port.dto.ts
+++ b/server/src/database/dtos/admin/admin.outbound-port.dto.ts
@@ -1,11 +1,9 @@
-import { Admin, MainPosting } from '@prisma/client';
-import { DateAndBigIntToString } from 'src/utils/types/date-to-string.type';
+import { AdminEntity } from 'src/database/models/admin/admin.entity';
+import { MainPostingEntity } from 'src/database/models/main-posting/main-posting.entity';
 
-export type FindOneAdminExceptPasswordDto = DateAndBigIntToString<
-  Omit<Admin, 'password'>
->;
+export type FindOneAdminExceptPasswordDto = Omit<AdminEntity.Admin, 'password'>;
 
 export interface FindAdminInfoForCommonDto
-  extends Pick<Admin, 'id' | 'nickname' | 'introduction'> {
-  mainPostings: DateAndBigIntToString<MainPosting>[];
+  extends Pick<AdminEntity.Admin, 'id' | 'nickname' | 'introduction'> {
+  mainPostings: MainPostingEntity.MainPosting[];
 }

--- a/server/src/database/dtos/auth/admin-login.dto.ts
+++ b/server/src/database/dtos/auth/admin-login.dto.ts
@@ -1,8 +1,8 @@
-import { Admin } from '@prisma/client';
+import { AdminEntity } from 'src/database/models/admin/admin.entity';
 import { UserType } from 'src/database/values/user-type.value';
 
 export type AdminLogInDto = Pick<
-  Admin,
+  AdminEntity.Admin,
   'id' | 'email' | 'gradeId' | 'nickname'
 >;
 

--- a/server/src/database/models/admin/admin-grade.entity.ts
+++ b/server/src/database/models/admin/admin-grade.entity.ts
@@ -1,0 +1,8 @@
+export interface AdminGradeEntity {
+  /**
+   * @type int
+   */
+  id: number;
+
+  name: string;
+}

--- a/server/src/database/models/admin/admin.entity.ts
+++ b/server/src/database/models/admin/admin.entity.ts
@@ -1,0 +1,44 @@
+import { CommonDateEntity } from '../common/common-date.entity';
+
+export namespace AdminEntity {
+  export interface Admin extends CommonDateEntity {
+    /**
+     * @type int
+     */
+    id: number;
+
+    /**
+     * @format email
+     */
+    email: string;
+
+    password: string;
+
+    firstName: string;
+
+    middleName: string | null;
+
+    lastName: string;
+
+    nickname: string;
+
+    introduction: string | null;
+
+    /**
+     * @format date
+     */
+    birth: string;
+
+    emailReception: boolean;
+
+    /**
+     * @type int
+     */
+    gradeId: number;
+
+    /**
+     * @type int
+     */
+    genderId: number;
+  }
+}

--- a/server/src/database/models/common/common-date.entity.ts
+++ b/server/src/database/models/common/common-date.entity.ts
@@ -1,0 +1,16 @@
+export interface CommonDateEntity {
+  /**
+   * @format date-time
+   */
+  createdAt: string | null;
+
+  /**
+   * @format date-time
+   */
+  updatedAt: string | null;
+
+  /**
+   * @format date-time
+   */
+  deletedAt: string | null;
+}

--- a/server/src/database/models/common/gender.entity.ts
+++ b/server/src/database/models/common/gender.entity.ts
@@ -1,0 +1,8 @@
+export interface GenderEntity {
+  /**
+   * @type int
+   */
+  id: number;
+
+  name: string;
+}

--- a/server/src/database/models/main-posting/main-posting-category.entity.ts
+++ b/server/src/database/models/main-posting/main-posting-category.entity.ts
@@ -1,0 +1,18 @@
+export interface MainPostingCategoryEntity {
+  /**
+   * @type int
+   */
+  id: number;
+
+  name: string;
+
+  /**
+   * @type int
+   */
+  parentId: number;
+
+  /**
+   * @type int
+   */
+  orderId: number;
+}

--- a/server/src/database/models/main-posting/main-posting-report.entity.ts
+++ b/server/src/database/models/main-posting/main-posting-report.entity.ts
@@ -1,0 +1,15 @@
+export interface MainPostingReportEntity {
+  /**
+   * @pattern ^[1-9][0-9]{1,17}
+   */
+  id: string;
+
+  title: string;
+
+  content: string;
+
+  /**
+   * @pattern ^[1-9][0-9]{1,17}
+   */
+  mainPostingId: string;
+}

--- a/server/src/database/models/main-posting/main-posting.entity.ts
+++ b/server/src/database/models/main-posting/main-posting.entity.ts
@@ -1,0 +1,24 @@
+import { CommonDateEntity } from '../common/common-date.entity';
+
+export namespace MainPostingEntity {
+  export interface MainPosting extends CommonDateEntity {
+    /**
+     * @pattern ^[1-9][0-9]{1,17}
+     */
+    id: string; // Max : 9223372036854775807
+
+    title: string;
+
+    content: string;
+
+    /**
+     * @type int
+     */
+    categoryId: number;
+
+    /**
+     * @type int
+     */
+    adminId: number;
+  }
+}

--- a/server/src/database/repositories/admin.repository.ts
+++ b/server/src/database/repositories/admin.repository.ts
@@ -8,10 +8,9 @@ import {
 } from '../dtos/admin/admin.outbound-port.dto';
 import typia from 'typia';
 import { TypeToSelect } from 'src/utils/types/type-to-select.type';
-import { Admin } from '@prisma/client';
 import { AdminSignUpInputDto } from '../dtos/admin/admin.inbound-port.dto';
-import { DateAndBigIntToString } from 'src/utils/types/date-to-string.type';
 import { dateAndBigIntToString } from 'src/utils/functions/date-and-bigint-to-string.function';
+import { AdminEntity } from '../models/admin/admin.entity';
 
 @Injectable()
 export class AdminRepository implements AdminRepositoryOutboundPort {
@@ -28,16 +27,10 @@ export class AdminRepository implements AdminRepositoryOutboundPort {
     return dateAndBigIntToString(admin);
   }
 
-  async findOneAdminForSign(
-    email: string,
-  ): Promise<DateAndBigIntToString<Admin> | null> {
+  async findOneAdminForSign(email: string): Promise<AdminEntity.Admin | null> {
     const admin = await this.prisma.admin.findFirst({
       where: { email },
     });
-
-    if (!admin) {
-      throw new BadRequestException('email is wrong');
-    }
 
     return dateAndBigIntToString(admin);
   }
@@ -50,10 +43,6 @@ export class AdminRepository implements AdminRepositoryOutboundPort {
       where: options,
     });
 
-    if (!admin) {
-      throw new BadRequestException('Incorrect options');
-    }
-
     return dateAndBigIntToString(admin);
   }
 
@@ -64,10 +53,6 @@ export class AdminRepository implements AdminRepositoryOutboundPort {
       select: typia.random<TypeToSelect<FindAdminInfoForCommonDto>>(),
       where: options,
     });
-
-    if (!admin) {
-      throw new BadRequestException('Incorrect options');
-    }
 
     return dateAndBigIntToString(admin);
   }

--- a/server/src/database/repositories/admin.repository.ts
+++ b/server/src/database/repositories/admin.repository.ts
@@ -11,7 +11,7 @@ import { TypeToSelect } from 'src/utils/types/type-to-select.type';
 import { Admin } from '@prisma/client';
 import { AdminSignUpInputDto } from '../dtos/admin/admin.inbound-port.dto';
 import { DateAndBigIntToString } from 'src/utils/types/date-to-string.type';
-import { dateAndBigIntToString } from 'src/utils/functions/date-bigint-to-string.function';
+import { dateAndBigIntToString } from 'src/utils/functions/date-and-bigint-to-string.function';
 
 @Injectable()
 export class AdminRepository implements AdminRepositoryOutboundPort {

--- a/server/src/database/repositories/outbound-ports/admin-repository.outbound-port.ts
+++ b/server/src/database/repositories/outbound-ports/admin-repository.outbound-port.ts
@@ -1,11 +1,10 @@
-import { Admin } from '@prisma/client';
 import { AdminOptionsDto } from 'src/database/dtos/admin/admin-options.dto';
 import { AdminSignUpInputDto } from 'src/database/dtos/admin/admin.inbound-port.dto';
 import {
   FindAdminInfoForCommonDto,
   FindOneAdminExceptPasswordDto,
 } from 'src/database/dtos/admin/admin.outbound-port.dto';
-import { DateAndBigIntToString } from 'src/utils/types/date-to-string.type';
+import { AdminEntity } from 'src/database/models/admin/admin.entity';
 
 export const ADMIN_REPOSITORY_OUTBOUND_PORT =
   'ADMIN_REPOSITORY_OUTBOUND_PORT' as const;
@@ -15,9 +14,7 @@ export interface AdminRepositoryOutboundPort {
     adminInfo: AdminSignUpInputDto,
   ): Promise<FindOneAdminExceptPasswordDto | null>;
 
-  findOneAdminForSign(
-    email: string,
-  ): Promise<DateAndBigIntToString<Admin> | null>;
+  findOneAdminForSign(email: string): Promise<AdminEntity.Admin | null>;
 
   findOneAdminByOptions(
     options: AdminOptionsDto,

--- a/server/src/test/unit/admin.spec.ts
+++ b/server/src/test/unit/admin.spec.ts
@@ -1,5 +1,4 @@
 import { JwtService } from '@nestjs/jwt';
-import { Admin } from '@prisma/client';
 import { AuthController } from 'src/auth/auth.controller';
 import { AuthService } from 'src/auth/auth.service';
 import { AdminSignUpInputDto } from 'src/database/dtos/admin/admin.inbound-port.dto';
@@ -8,74 +7,10 @@ import {
   FindOneAdminExceptPasswordDto,
 } from 'src/database/dtos/admin/admin.outbound-port.dto';
 import { AdminLogInDto } from 'src/database/dtos/auth/admin-login.dto';
-import { AdminRepositoryOutboundPort } from 'src/database/repositories/outbound-ports/admin-repository.outbound-port';
 import { AdminController } from 'src/domain/admin/admin.controller';
 import { AdminService } from 'src/domain/admin/admin.service';
-import { DateAndBigIntToString } from 'src/utils/types/date-to-string.type';
 import typia from 'typia';
-
-/**
- * 동일한 repository 함수를 두 번 호출할 경우, 결과 값을 1개만 쓸수 밖에 없다는 단점이 있다.
- * 그래서 차라리 Array형식으로 만들어서 함수 호출할 때 마다, pop을 하는 형식으로 하도록 만들었다.
- * 어차피, pop으로 변수에 한 번 할당하면, 해당 변수를 이용해서 동일한 값을 재사용 할 수 있으니까.
- */
-type MockAdminRepositoryParamType = {
-  insertAdmin?: Array<FindOneAdminExceptPasswordDto>;
-  findOneAdminForSign?: Array<DateAndBigIntToString<Admin> | null>;
-  findOneAdminByOptions?: Array<FindOneAdminExceptPasswordDto | null>;
-  findOneAdminForCommon?: Array<FindAdminInfoForCommonDto | null>;
-};
-
-class MockAdminRepository implements AdminRepositoryOutboundPort {
-  private readonly result: MockAdminRepositoryParamType;
-
-  constructor(result: MockAdminRepositoryParamType) {
-    this.result = result;
-  }
-
-  async insertAdmin(
-    adminInfo: AdminSignUpInputDto,
-  ): Promise<FindOneAdminExceptPasswordDto | null> {
-    const res = this.result.insertAdmin?.pop();
-    if (!res && res !== null) {
-      throw new Error('undefined');
-    }
-
-    return res;
-  }
-  async findOneAdminForSign(
-    email: string,
-  ): Promise<DateAndBigIntToString<Admin> | null> {
-    const res = this.result.findOneAdminForSign?.pop();
-    if (!res && res !== null) {
-      throw new Error('undefined');
-    }
-
-    return res;
-  }
-
-  async findOneAdminByOptions(
-    options: Partial<Pick<Admin, 'id' | 'email' | 'nickname' | 'gradeId'>>,
-  ): Promise<FindOneAdminExceptPasswordDto | null> {
-    const res = this.result.findOneAdminByOptions?.pop();
-    if (!res && res !== null) {
-      throw new Error('undefined');
-    }
-
-    return res;
-  }
-
-  async findOneAdminForCommon(
-    options: Partial<Pick<Admin, 'id' | 'email' | 'nickname' | 'gradeId'>>,
-  ): Promise<FindAdminInfoForCommonDto | null> {
-    const res = this.result.findOneAdminForCommon?.pop();
-    if (!res && res !== null) {
-      throw new Error('undefined');
-    }
-
-    return res;
-  }
-}
+import { MockAdminRepository } from './mock/admin.repository.mock';
 
 describe('Admin Spec', () => {
   describe('1. Validate Admin', () => {

--- a/server/src/test/unit/mock/admin.repository.mock.ts
+++ b/server/src/test/unit/mock/admin.repository.mock.ts
@@ -1,0 +1,70 @@
+import { AdminOptionsDto } from 'src/database/dtos/admin/admin-options.dto';
+import { AdminSignUpInputDto } from 'src/database/dtos/admin/admin.inbound-port.dto';
+import {
+  FindAdminInfoForCommonDto,
+  FindOneAdminExceptPasswordDto,
+} from 'src/database/dtos/admin/admin.outbound-port.dto';
+import { AdminEntity } from 'src/database/models/admin/admin.entity';
+import { AdminRepositoryOutboundPort } from 'src/database/repositories/outbound-ports/admin-repository.outbound-port';
+
+/**
+ * 동일한 repository 함수를 두 번 호출할 경우, 결과 값을 1개만 쓸수 밖에 없다는 단점이 있다.
+ * 그래서 차라리 Array형식으로 만들어서 함수 호출할 때 마다, pop을 하는 형식으로 하도록 만들었다.
+ * 어차피, pop으로 변수에 한 번 할당하면, 해당 변수를 이용해서 동일한 값을 재사용 할 수 있으니까.
+ */
+type MockAdminRepositoryParamType = {
+  [P in keyof AdminRepositoryOutboundPort]?: AdminRepositoryOutboundPort[P] extends (
+    ...args: any[]
+  ) => infer K
+    ? Array<Awaited<K>>
+    : never;
+};
+
+export class MockAdminRepository implements AdminRepositoryOutboundPort {
+  private readonly result: MockAdminRepositoryParamType;
+
+  constructor(result: MockAdminRepositoryParamType) {
+    this.result = result;
+  }
+
+  async insertAdmin(
+    adminInfo: AdminSignUpInputDto,
+  ): Promise<FindOneAdminExceptPasswordDto | null> {
+    const res = this.result.insertAdmin?.pop();
+    if (res === undefined) {
+      throw new Error('undefined');
+    }
+
+    return res;
+  }
+  async findOneAdminForSign(email: string): Promise<AdminEntity.Admin | null> {
+    const res = this.result.findOneAdminForSign?.pop();
+    if (res === undefined) {
+      throw new Error('undefined');
+    }
+
+    return res;
+  }
+
+  async findOneAdminByOptions(
+    options: AdminOptionsDto,
+  ): Promise<FindOneAdminExceptPasswordDto | null> {
+    const res = this.result.findOneAdminByOptions?.pop();
+    if (res === undefined) {
+      throw new Error('undefined');
+    }
+
+    return res;
+  }
+
+  async findOneAdminForCommon(
+    options: AdminOptionsDto,
+  ): Promise<FindAdminInfoForCommonDto | null> {
+    const res = this.result.findOneAdminForCommon?.pop();
+    if (res === undefined) {
+      throw new Error('undefined');
+    }
+
+    return res;
+  }
+}

--- a/server/src/utils/functions/date-and-bigint-to-string.function.ts
+++ b/server/src/utils/functions/date-and-bigint-to-string.function.ts
@@ -1,8 +1,12 @@
 import { DateAndBigIntToString } from '../types/date-to-string.type';
 
 export function dateAndBigIntToString<T extends object>(
-  target: T,
-): DateAndBigIntToString<T> {
+  target: T | null,
+): DateAndBigIntToString<T> | null {
+  if (target === null) {
+    return null;
+  }
+
   try {
     const res = Object.entries(target).reduce((acc, [key, value]) => {
       if (value === null) {


### PR DESCRIPTION
## 개요

- Dto를 prisma의 schema로부터 분리한다.

## ✅ 작업 내용

- AdminEntity
- AdminGradeEntity
- GenderEntity
- MainPostingEntity
- MainPostingCategoryEntity
- MainPostingReportEntity
- CommonDateEntity

## 🔨 변경 로직

- 모든 bigint, Date관련 칼럼들은 string 타입으로 지정하고 typia comment 추가
- prisma schema를 참조하던 Dto들은 새로 만든 Entity를 참조하도록 변경
- dateAndBigIntToString function의 null 리턴타입 추가.
- MockAdminRepository의 경로 변경
- MockAdminRepositoryParamType 변경

## 🧨 관련 이슈

- close #14 
