### PR TITLE
Feat : change password

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -17,6 +17,7 @@
         "@nestjs/passport": "^9.0.3",
         "@nestjs/platform-express": "^9.0.0",
         "@prisma/client": "^4.14.1",
+        "@types/bcrypt": "^5.0.0",
         "bcrypt": "^5.1.0",
         "passport": "^0.6.0",
         "passport-jwt": "^4.0.1",
@@ -2103,6 +2104,14 @@
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.3.0"
+      }
+    },
+    "node_modules/@types/bcrypt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-5.0.0.tgz",
+      "integrity": "sha512-agtcFKaruL8TmcvqbndlqHPSJgsolhf/qPWchFlgnW1gECTN/nKbFcoFnvKAQRFfKbh+BO6A3SWdJu9t+xF3Lw==",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/body-parser": {
@@ -10887,6 +10896,14 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.3.0"
+      }
+    },
+    "@types/bcrypt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-5.0.0.tgz",
+      "integrity": "sha512-agtcFKaruL8TmcvqbndlqHPSJgsolhf/qPWchFlgnW1gECTN/nKbFcoFnvKAQRFfKbh+BO6A3SWdJu9t+xF3Lw==",
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@types/body-parser": {

--- a/server/package.json
+++ b/server/package.json
@@ -30,6 +30,7 @@
     "@nestjs/passport": "^9.0.3",
     "@nestjs/platform-express": "^9.0.0",
     "@prisma/client": "^4.14.1",
+    "@types/bcrypt": "^5.0.0",
     "bcrypt": "^5.1.0",
     "passport": "^0.6.0",
     "passport-jwt": "^4.0.1",

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -63,7 +63,7 @@ export class AuthService {
       throw new BadRequestException('Admin already exists');
     }
 
-    const hashedPassword = await bcrypt.hash(adminInfo.password, 10);
+    const hashedPassword = await bcrypt.hash(adminInfo.password, BCRYPT_SALT);
 
     adminInfo.password = hashedPassword;
 

--- a/server/src/database/dtos/admin/admin.inbound-port.dto.ts
+++ b/server/src/database/dtos/admin/admin.inbound-port.dto.ts
@@ -1,4 +1,6 @@
 import { AdminEntity } from 'src/database/models/admin/admin.entity';
+import { CommonDateEntity } from 'src/database/models/common/common-date.entity';
+import { OmitAmongObject } from 'src/utils/types/omit-among-object.type';
 
 export type AdminSignUpInputDto = Pick<
   AdminEntity.Admin,
@@ -13,4 +15,10 @@ export type AdminSignUpInputDto = Pick<
   | 'birth'
   | 'introduction'
   | 'middleName'
+>;
+
+export type UpdateAdminPasswordInputDto = Pick<AdminEntity.Admin, 'password'>;
+
+export type UpdateAdminInputDto = Partial<
+  OmitAmongObject<AdminEntity.Admin, CommonDateEntity>
 >;

--- a/server/src/database/repositories/admin.repository.ts
+++ b/server/src/database/repositories/admin.repository.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/database/prisma/prisma.service';
 import { AdminRepositoryOutboundPort } from './outbound-ports/admin-repository.outbound-port';
 import { AdminOptionsDto } from '../dtos/admin/admin-options.dto';
@@ -8,7 +8,10 @@ import {
 } from '../dtos/admin/admin.outbound-port.dto';
 import typia from 'typia';
 import { TypeToSelect } from 'src/utils/types/type-to-select.type';
-import { AdminSignUpInputDto } from '../dtos/admin/admin.inbound-port.dto';
+import {
+  AdminSignUpInputDto,
+  UpdateAdminInputDto,
+} from '../dtos/admin/admin.inbound-port.dto';
 import { dateAndBigIntToString } from 'src/utils/functions/date-and-bigint-to-string.function';
 import { AdminEntity } from '../models/admin/admin.entity';
 
@@ -52,6 +55,19 @@ export class AdminRepository implements AdminRepositoryOutboundPort {
     const admin = await this.prisma.admin.findFirst({
       select: typia.random<TypeToSelect<FindAdminInfoForCommonDto>>(),
       where: options,
+    });
+
+    return dateAndBigIntToString(admin);
+  }
+
+  async updateAdmin(
+    id: number,
+    data: UpdateAdminInputDto,
+  ): Promise<FindOneAdminExceptPasswordDto | null> {
+    const admin = await this.prisma.admin.update({
+      data: data,
+      where: { id },
+      select: typia.random<TypeToSelect<FindOneAdminExceptPasswordDto>>(),
     });
 
     return dateAndBigIntToString(admin);

--- a/server/src/database/repositories/outbound-ports/admin-repository.outbound-port.ts
+++ b/server/src/database/repositories/outbound-ports/admin-repository.outbound-port.ts
@@ -1,5 +1,8 @@
 import { AdminOptionsDto } from 'src/database/dtos/admin/admin-options.dto';
-import { AdminSignUpInputDto } from 'src/database/dtos/admin/admin.inbound-port.dto';
+import {
+  AdminSignUpInputDto,
+  UpdateAdminInputDto,
+} from 'src/database/dtos/admin/admin.inbound-port.dto';
 import {
   FindAdminInfoForCommonDto,
   FindOneAdminExceptPasswordDto,
@@ -23,4 +26,9 @@ export interface AdminRepositoryOutboundPort {
   findOneAdminForCommon(
     options: AdminOptionsDto,
   ): Promise<FindAdminInfoForCommonDto | null>;
+
+  updateAdmin(
+    id: number,
+    data: UpdateAdminInputDto,
+  ): Promise<FindOneAdminExceptPasswordDto | null>;
 }

--- a/server/src/domain/admin/admin.controller.ts
+++ b/server/src/domain/admin/admin.controller.ts
@@ -1,11 +1,11 @@
 import { Controller, UnauthorizedException, UseGuards } from '@nestjs/common';
 import { AdminService } from './admin.service';
-import { TypedParam, TypedRoute } from '@nestia/core';
+import { TypedBody, TypedParam, TypedRoute } from '@nestia/core';
 import { JwtAdminGuard } from 'src/auth/guards/jwt-admin.guard';
 import { User } from 'src/common/decorators/user.decorator';
 import { AdminLogInDto } from 'src/database/dtos/auth/admin-login.dto';
 import { FindOneAdminExceptPasswordDto } from 'src/database/dtos/admin/admin.outbound-port.dto';
-import typia from 'typia';
+import { UpdateAdminPasswordInputDto } from 'src/database/dtos/admin/admin.inbound-port.dto';
 
 @Controller('api/v1/admin')
 export class AdminController {
@@ -29,6 +29,24 @@ export class AdminController {
   @TypedRoute.Get(':id/info')
   async getAdminInfoForCommon(@TypedParam('id') id: number) {
     const admin = await this.adminService.getAdminInfoForCommon({ id });
+
+    return admin;
+  }
+
+  @UseGuards(JwtAdminGuard)
+  @TypedRoute.Put(':id')
+  async modifyPassword(
+    @TypedParam('id') id: number,
+    @TypedBody() body: UpdateAdminPasswordInputDto,
+    @User() user: AdminLogInDto,
+  ): Promise<FindOneAdminExceptPasswordDto> {
+    if (id !== user.id) {
+      throw new UnauthorizedException('UnAuthorized');
+    }
+
+    const admin = await this.adminService.modifyAdminInfo(user.id, {
+      password: body.password,
+    });
 
     return admin;
   }

--- a/server/src/domain/admin/admin.service.ts
+++ b/server/src/domain/admin/admin.service.ts
@@ -6,6 +6,7 @@ import {
   ADMIN_REPOSITORY_OUTBOUND_PORT,
   AdminRepositoryOutboundPort,
 } from 'src/database/repositories/outbound-ports/admin-repository.outbound-port';
+import * as bcrypt from 'bcrypt';
 
 @Injectable()
 export class AdminService {
@@ -40,6 +41,10 @@ export class AdminService {
     id: number,
     data: UpdateAdminInputDto,
   ): Promise<FindOneAdminExceptPasswordDto> {
+    if (data.password) {
+      data.password = await bcrypt.hash(data.password, BCRYPT_SALT);
+    }
+
     const admin = await this.adminRepo.updateAdmin(id, data);
 
     if (!admin) {

--- a/server/src/domain/admin/admin.service.ts
+++ b/server/src/domain/admin/admin.service.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import { AdminOptionsDto } from 'src/database/dtos/admin/admin-options.dto';
+import { UpdateAdminInputDto } from 'src/database/dtos/admin/admin.inbound-port.dto';
 import { FindOneAdminExceptPasswordDto } from 'src/database/dtos/admin/admin.outbound-port.dto';
 import {
   ADMIN_REPOSITORY_OUTBOUND_PORT,
@@ -27,6 +28,19 @@ export class AdminService {
 
   async getAdminInfoForCommon(options: AdminOptionsDto) {
     const admin = await this.adminRepo.findOneAdminForCommon(options);
+
+    if (!admin) {
+      throw new BadRequestException('Option is incorrect');
+    }
+
+    return admin;
+  }
+
+  async modifyAdminInfo(
+    id: number,
+    data: UpdateAdminInputDto,
+  ): Promise<FindOneAdminExceptPasswordDto> {
+    const admin = await this.adminRepo.updateAdmin(id, data);
 
     if (!admin) {
       throw new BadRequestException('Option is incorrect');

--- a/server/src/test/unit/admin.spec.ts
+++ b/server/src/test/unit/admin.spec.ts
@@ -56,7 +56,27 @@ describe('Admin Spec', () => {
 
   describe('3. Update Admin', () => {
     it.todo('3-1. 닉네임을 변경합니다.');
-    it.todo('3-2. 비밀번호를 변경합니다.');
+    it('3-2. 비밀번호를 변경합니다.', async () => {
+      const admin = typia.random<FindOneAdminExceptPasswordDto>();
+
+      const password = '1234';
+
+      const adminService = new AdminService(
+        new MockAdminRepository({
+          updateAdmin: [{ ...admin }],
+        }),
+      );
+
+      const adminController = new AdminController(adminService);
+
+      const res = await adminController.modifyPassword(
+        admin.id,
+        { password },
+        { ...admin },
+      );
+
+      expect(res).toStrictEqual({ ...admin });
+    });
     it.todo('3-3. 기타 정보를 변경합니다.');
   });
 

--- a/server/src/test/unit/mock/admin.repository.mock.ts
+++ b/server/src/test/unit/mock/admin.repository.mock.ts
@@ -1,11 +1,16 @@
 import { AdminOptionsDto } from 'src/database/dtos/admin/admin-options.dto';
-import { AdminSignUpInputDto } from 'src/database/dtos/admin/admin.inbound-port.dto';
+import {
+  AdminSignUpInputDto,
+  UpdateAdminInputDto,
+} from 'src/database/dtos/admin/admin.inbound-port.dto';
 import {
   FindAdminInfoForCommonDto,
   FindOneAdminExceptPasswordDto,
 } from 'src/database/dtos/admin/admin.outbound-port.dto';
 import { AdminEntity } from 'src/database/models/admin/admin.entity';
+import { CommonDateEntity } from 'src/database/models/common/common-date.entity';
 import { AdminRepositoryOutboundPort } from 'src/database/repositories/outbound-ports/admin-repository.outbound-port';
+import { OmitAmongObject } from 'src/utils/types/omit-among-object.type';
 
 /**
  * 동일한 repository 함수를 두 번 호출할 경우, 결과 값을 1개만 쓸수 밖에 없다는 단점이 있다.
@@ -61,6 +66,18 @@ export class MockAdminRepository implements AdminRepositoryOutboundPort {
     options: AdminOptionsDto,
   ): Promise<FindAdminInfoForCommonDto | null> {
     const res = this.result.findOneAdminForCommon?.pop();
+    if (res === undefined) {
+      throw new Error('undefined');
+    }
+
+    return res;
+  }
+
+  async updateAdmin(
+    id: number,
+    data: UpdateAdminInputDto,
+  ): Promise<FindOneAdminExceptPasswordDto | null> {
+    const res = this.result.updateAdmin?.pop();
     if (res === undefined) {
       throw new Error('undefined');
     }

--- a/server/src/utils/types/omit-among-object.type.ts
+++ b/server/src/utils/types/omit-among-object.type.ts
@@ -1,0 +1,3 @@
+export type OmitAmongObject<T extends object, K extends object> = {
+  [P in keyof T as P extends keyof K ? never : P]: T[P];
+};


### PR DESCRIPTION
## 개요

- Admin 본인의 비밀번호를 변경할 수 있다.

## ✅ 작업 내용

- modifyPassword function in AdminController
- modifyAdminInfo function in AdminService
- updateAdmin function in AdminRepository
- install `@types/bcrypt`
- OmitAmongObject type
- define Dtos about UpdateAdmin
- modifyPassword test

## 🔨 변경 로직

- make a hash salt constant.

## 🧨 관련 이슈

- #8 
