### PR TITLE
Fix : fatal error about `typia.random<TypeToSelect<T>>`

### DIFF
--- a/server/src/auth/auth.controller.ts
+++ b/server/src/auth/auth.controller.ts
@@ -13,7 +13,6 @@ import { AdminSignUpInputDto } from 'src/database/dtos/admin/admin.inbound-port.
 import { FindOneAdminExceptPasswordDto } from 'src/database/dtos/admin/admin.outbound-port.dto';
 import { ADMIN_GRADE } from 'src/database/values/admin-grade.value';
 import { JwtMasterAdminGuard } from './guards/jwt-master-admin.guard';
-import { JwtAdminGuard } from './guards/jwt-admin.guard';
 
 @Controller('api/v1/auth')
 export class AuthController {
@@ -21,7 +20,9 @@ export class AuthController {
 
   @UseGuards(AdminGuard)
   @TypedRoute.Post('admin-login')
-  async adminSignIn(@User() user: AdminLogInDto) {
+  async adminSignIn(@User() user: AdminLogInDto): Promise<{
+    accessToken: string;
+  }> {
     const token = await this.authService.adminSignIn(user);
 
     return token;

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -11,6 +11,7 @@ import { JwtService } from '@nestjs/jwt';
 import { AdminSignUpInputDto } from 'src/database/dtos/admin/admin.inbound-port.dto';
 import { FindOneAdminExceptPasswordDto } from 'src/database/dtos/admin/admin.outbound-port.dto';
 import * as bcrypt from 'bcrypt';
+import { BCRYPT_SALT } from 'src/database/values/bcrypt-salt.value';
 
 @Injectable()
 export class AuthService {

--- a/server/src/database/dtos/select/admin-select.dto.ts
+++ b/server/src/database/dtos/select/admin-select.dto.ts
@@ -1,0 +1,12 @@
+import {
+  FindAdminInfoForCommonDto,
+  FindOneAdminExceptPasswordDto,
+} from '../admin/admin.outbound-port.dto';
+
+export type SelectFindOneAdminExceptPasswordDto = {
+  [P in keyof FindOneAdminExceptPasswordDto as `${P}`]: FindOneAdminExceptPasswordDto[P];
+};
+
+export type SelectFindAdminInfoForCommonDto = {
+  [P in keyof FindAdminInfoForCommonDto as `${P}`]: FindAdminInfoForCommonDto[P];
+};

--- a/server/src/database/dtos/select/common-date.type.ts
+++ b/server/src/database/dtos/select/common-date.type.ts
@@ -1,0 +1,5 @@
+export interface SelectCommonDate {
+  createdAt: string | null;
+  updatedAt: string | null;
+  deletedAt: string | null;
+}

--- a/server/src/database/repositories/admin.repository.ts
+++ b/server/src/database/repositories/admin.repository.ts
@@ -14,6 +14,10 @@ import {
 } from '../dtos/admin/admin.inbound-port.dto';
 import { dateAndBigIntToString } from 'src/utils/functions/date-and-bigint-to-string.function';
 import { AdminEntity } from '../models/admin/admin.entity';
+import {
+  SelectFindAdminInfoForCommonDto,
+  SelectFindOneAdminExceptPasswordDto,
+} from '../dtos/select/admin-select.dto';
 
 @Injectable()
 export class AdminRepository implements AdminRepositoryOutboundPort {
@@ -24,7 +28,7 @@ export class AdminRepository implements AdminRepositoryOutboundPort {
   ): Promise<FindOneAdminExceptPasswordDto | null> {
     const admin = await this.prisma.admin.create({
       data: adminInfo,
-      select: typia.random<TypeToSelect<FindOneAdminExceptPasswordDto>>(),
+      select: typia.random<TypeToSelect<SelectFindOneAdminExceptPasswordDto>>(),
     });
 
     return dateAndBigIntToString(admin);
@@ -42,7 +46,7 @@ export class AdminRepository implements AdminRepositoryOutboundPort {
     options: AdminOptionsDto,
   ): Promise<FindOneAdminExceptPasswordDto | null> {
     const admin = await this.prisma.admin.findFirst({
-      select: typia.random<TypeToSelect<FindOneAdminExceptPasswordDto>>(),
+      select: typia.random<TypeToSelect<SelectFindOneAdminExceptPasswordDto>>(),
       where: options,
     });
 
@@ -53,7 +57,7 @@ export class AdminRepository implements AdminRepositoryOutboundPort {
     options: AdminOptionsDto,
   ): Promise<FindAdminInfoForCommonDto | null> {
     const admin = await this.prisma.admin.findFirst({
-      select: typia.random<TypeToSelect<FindAdminInfoForCommonDto>>(),
+      select: typia.random<TypeToSelect<SelectFindAdminInfoForCommonDto>>(),
       where: options,
     });
 
@@ -67,7 +71,7 @@ export class AdminRepository implements AdminRepositoryOutboundPort {
     const admin = await this.prisma.admin.update({
       data: data,
       where: { id },
-      select: typia.random<TypeToSelect<FindOneAdminExceptPasswordDto>>(),
+      select: typia.random<TypeToSelect<SelectFindOneAdminExceptPasswordDto>>(),
     });
 
     return dateAndBigIntToString(admin);

--- a/server/src/domain/admin/admin.controller.ts
+++ b/server/src/domain/admin/admin.controller.ts
@@ -4,7 +4,10 @@ import { TypedBody, TypedParam, TypedRoute } from '@nestia/core';
 import { JwtAdminGuard } from 'src/auth/guards/jwt-admin.guard';
 import { User } from 'src/common/decorators/user.decorator';
 import { AdminLogInDto } from 'src/database/dtos/auth/admin-login.dto';
-import { FindOneAdminExceptPasswordDto } from 'src/database/dtos/admin/admin.outbound-port.dto';
+import {
+  FindAdminInfoForCommonDto,
+  FindOneAdminExceptPasswordDto,
+} from 'src/database/dtos/admin/admin.outbound-port.dto';
 import { UpdateAdminPasswordInputDto } from 'src/database/dtos/admin/admin.inbound-port.dto';
 
 @Controller('api/v1/admin')
@@ -27,7 +30,9 @@ export class AdminController {
   }
 
   @TypedRoute.Get(':id/info')
-  async getAdminInfoForCommon(@TypedParam('id') id: number) {
+  async getAdminInfoForCommon(
+    @TypedParam('id') id: number,
+  ): Promise<FindAdminInfoForCommonDto> {
     const admin = await this.adminService.getAdminInfoForCommon({ id });
 
     return admin;

--- a/server/src/domain/admin/admin.service.ts
+++ b/server/src/domain/admin/admin.service.ts
@@ -10,6 +10,7 @@ import {
   AdminRepositoryOutboundPort,
 } from 'src/database/repositories/outbound-ports/admin-repository.outbound-port';
 import * as bcrypt from 'bcrypt';
+import { BCRYPT_SALT } from 'src/database/values/bcrypt-salt.value';
 
 @Injectable()
 export class AdminService {

--- a/server/src/domain/admin/admin.service.ts
+++ b/server/src/domain/admin/admin.service.ts
@@ -1,7 +1,10 @@
 import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import { AdminOptionsDto } from 'src/database/dtos/admin/admin-options.dto';
 import { UpdateAdminInputDto } from 'src/database/dtos/admin/admin.inbound-port.dto';
-import { FindOneAdminExceptPasswordDto } from 'src/database/dtos/admin/admin.outbound-port.dto';
+import {
+  FindAdminInfoForCommonDto,
+  FindOneAdminExceptPasswordDto,
+} from 'src/database/dtos/admin/admin.outbound-port.dto';
 import {
   ADMIN_REPOSITORY_OUTBOUND_PORT,
   AdminRepositoryOutboundPort,
@@ -27,7 +30,9 @@ export class AdminService {
     return admin;
   }
 
-  async getAdminInfoForCommon(options: AdminOptionsDto) {
+  async getAdminInfoForCommon(
+    options: AdminOptionsDto,
+  ): Promise<FindAdminInfoForCommonDto> {
     const admin = await this.adminRepo.findOneAdminForCommon(options);
 
     if (!admin) {


### PR DESCRIPTION
## 개요

- select를 위해 typia.random 함수 사용시, typia comment 때문에 잘 동작하지 않는 문제가 있었다.
- typia comment를 없앤 타입을 새로 만들어서 TypeToSelect에 적용하여 사용할 수 있게 되었다.

## ✅ 작업 내용

- new Type For TypeToSelect (typia.random for prisma select)
- add return type to untyped function

## 🔨 변경 로직

- export BCRYPT_SALE constant

## 🧨 관련 이슈


