### PR TITLE
Feat : change nickname

### DIFF
--- a/server/src/database/dtos/admin/admin.inbound-port.dto.ts
+++ b/server/src/database/dtos/admin/admin.inbound-port.dto.ts
@@ -19,6 +19,8 @@ export type AdminSignUpInputDto = Pick<
 
 export type UpdateAdminPasswordInputDto = Pick<AdminEntity.Admin, 'password'>;
 
+export type UpdateAdminNicknameInputDto = Pick<AdminEntity.Admin, 'nickname'>;
+
 export type UpdateAdminInputDto = Partial<
-  OmitAmongObject<AdminEntity.Admin, CommonDateEntity>
+  Omit<OmitAmongObject<AdminEntity.Admin, CommonDateEntity>, 'id' | 'gradeId'>
 >;

--- a/server/src/domain/admin/admin.controller.ts
+++ b/server/src/domain/admin/admin.controller.ts
@@ -8,7 +8,11 @@ import {
   FindAdminInfoForCommonDto,
   FindOneAdminExceptPasswordDto,
 } from 'src/database/dtos/admin/admin.outbound-port.dto';
-import { UpdateAdminPasswordInputDto } from 'src/database/dtos/admin/admin.inbound-port.dto';
+import {
+  UpdateAdminNicknameInputDto,
+  UpdateAdminPasswordInputDto,
+} from 'src/database/dtos/admin/admin.inbound-port.dto';
+import { AdminEntity } from 'src/database/models/admin/admin.entity';
 
 @Controller('api/v1/admin')
 export class AdminController {
@@ -51,6 +55,24 @@ export class AdminController {
 
     const admin = await this.adminService.modifyAdminInfo(user.id, {
       password: body.password,
+    });
+
+    return admin;
+  }
+
+  @UseGuards(JwtAdminGuard)
+  @TypedRoute.Put(':id')
+  async modifyNickname(
+    @TypedParam('id') id: number,
+    @TypedBody() body: UpdateAdminNicknameInputDto,
+    @User() user: AdminLogInDto,
+  ): Promise<FindOneAdminExceptPasswordDto> {
+    if (id !== user.id) {
+      throw new UnauthorizedException('UnAuthorized');
+    }
+
+    const admin = await this.adminService.modifyAdminInfo(user.id, {
+      nickname: body.nickname,
     });
 
     return admin;

--- a/server/src/domain/admin/admin.controller.ts
+++ b/server/src/domain/admin/admin.controller.ts
@@ -43,7 +43,7 @@ export class AdminController {
   }
 
   @UseGuards(JwtAdminGuard)
-  @TypedRoute.Put(':id')
+  @TypedRoute.Put(':id/password')
   async modifyPassword(
     @TypedParam('id') id: number,
     @TypedBody() body: UpdateAdminPasswordInputDto,
@@ -61,7 +61,7 @@ export class AdminController {
   }
 
   @UseGuards(JwtAdminGuard)
-  @TypedRoute.Put(':id')
+  @TypedRoute.Put(':id/nickname')
   async modifyNickname(
     @TypedParam('id') id: number,
     @TypedBody() body: UpdateAdminNicknameInputDto,

--- a/server/src/test/unit/admin.spec.ts
+++ b/server/src/test/unit/admin.spec.ts
@@ -55,7 +55,30 @@ describe('Admin Spec', () => {
   });
 
   describe('3. Update Admin', () => {
-    it.todo('3-1. 닉네임을 변경합니다.');
+    it('3-1. 닉네임을 변경합니다.', async () => {
+      const admin = typia.random<FindOneAdminExceptPasswordDto>();
+
+      const nickname = 'testNickname';
+
+      const adminService = new AdminService(
+        new MockAdminRepository({
+          updateAdmin: [{ ...admin, nickname }],
+        }),
+      );
+
+      const adminController = new AdminController(adminService);
+
+      const res = await adminController.modifyNickname(
+        admin.id,
+        {
+          nickname,
+        },
+        { ...admin },
+      );
+
+      expect(res).toStrictEqual({ ...admin, nickname });
+    });
+
     it('3-2. 비밀번호를 변경합니다.', async () => {
       const admin = typia.random<FindOneAdminExceptPasswordDto>();
 

--- a/server/src/test/unit/admin.spec.ts
+++ b/server/src/test/unit/admin.spec.ts
@@ -100,6 +100,7 @@ describe('Admin Spec', () => {
 
       expect(res).toStrictEqual({ ...admin });
     });
+    it.todo('3-4. 이메일을 변경합니다.');
     it.todo('3-3. 기타 정보를 변경합니다.');
   });
 


### PR DESCRIPTION
## 개요

- Admin이 본인의 닉네임을 변경할 수 있다.

## ✅ 작업 내용

- modifyNickname function in AdminController
- modifyNickname test

## 🔨 변경 로직

- duplicate check for email, password, nickname in AdminSpec
- add modify email todo in AdminSpec
- url route in AdminController

## 🧨 관련 이슈

- #8 
