### PR TITLE
Feat : change info

### DIFF
--- a/server/src/database/dtos/admin/admin.inbound-port.dto.ts
+++ b/server/src/database/dtos/admin/admin.inbound-port.dto.ts
@@ -23,6 +23,11 @@ export type UpdateAdminNicknameInputDto = Pick<AdminEntity.Admin, 'nickname'>;
 
 export type UpdateAdminEmailInputDto = Pick<AdminEntity.Admin, 'email'>;
 
+export type UpdateAdminInfoInputDto = Omit<
+  UpdateAdminInputDto,
+  'password' | 'email' | 'nickname'
+>;
+
 export type UpdateAdminInputDto = Partial<
   Omit<OmitAmongObject<AdminEntity.Admin, CommonDateEntity>, 'id' | 'gradeId'>
 >;

--- a/server/src/domain/admin/admin.controller.ts
+++ b/server/src/domain/admin/admin.controller.ts
@@ -10,6 +10,7 @@ import {
 } from 'src/database/dtos/admin/admin.outbound-port.dto';
 import {
   UpdateAdminEmailInputDto,
+  UpdateAdminInfoInputDto,
   UpdateAdminNicknameInputDto,
   UpdateAdminPasswordInputDto,
 } from 'src/database/dtos/admin/admin.inbound-port.dto';
@@ -93,6 +94,22 @@ export class AdminController {
     const admin = await this.adminService.modifyAdminInfo(user.id, {
       email: body.email,
     });
+
+    return admin;
+  }
+
+  @UseGuards(JwtAdminGuard)
+  @TypedRoute.Put(':id')
+  async modifyAdminInfo(
+    @TypedParam('id') id: number,
+    @TypedBody() body: UpdateAdminInfoInputDto,
+    @User() user: AdminLogInDto,
+  ): Promise<FindOneAdminExceptPasswordDto> {
+    if (id !== user.id) {
+      throw new UnauthorizedException('UnAuthorized');
+    }
+
+    const admin = await this.adminService.modifyAdminInfo(user.id, body);
 
     return admin;
   }

--- a/server/src/test/unit/admin.spec.ts
+++ b/server/src/test/unit/admin.spec.ts
@@ -1,7 +1,10 @@
 import { JwtService } from '@nestjs/jwt';
 import { AuthController } from 'src/auth/auth.controller';
 import { AuthService } from 'src/auth/auth.service';
-import { AdminSignUpInputDto } from 'src/database/dtos/admin/admin.inbound-port.dto';
+import {
+  AdminSignUpInputDto,
+  UpdateAdminInfoInputDto,
+} from 'src/database/dtos/admin/admin.inbound-port.dto';
 import {
   FindAdminInfoForCommonDto,
   FindOneAdminExceptPasswordDto,
@@ -11,6 +14,7 @@ import { AdminController } from 'src/domain/admin/admin.controller';
 import { AdminService } from 'src/domain/admin/admin.service';
 import typia from 'typia';
 import { MockAdminRepository } from './mock/admin.repository.mock';
+import { OmitAmongObject } from 'src/utils/types/omit-among-object.type';
 
 describe('Admin Spec', () => {
   describe('1. Validate Admin', () => {
@@ -123,7 +127,25 @@ describe('Admin Spec', () => {
       expect(res).toStrictEqual({ ...admin, email });
     });
 
-    it.todo('3-3. 기타 정보를 변경합니다.');
+    it('3-3. 기타 정보를 변경합니다.', async () => {
+      const admin = typia.random<FindOneAdminExceptPasswordDto>();
+
+      const body = typia.random<UpdateAdminInfoInputDto>();
+
+      const adminService = new AdminService(
+        new MockAdminRepository({
+          updateAdmin: [{ ...admin, ...body }],
+        }),
+      );
+
+      const adminController = new AdminController(adminService);
+
+      const res = await adminController.modifyAdminInfo(admin.id, body, {
+        ...admin,
+      });
+
+      expect(res).toStrictEqual({ ...admin, ...body });
+    });
   });
 
   describe('4. Read Admin List', () => {
@@ -175,6 +197,7 @@ describe('Admin Spec', () => {
           secret: 'secret',
         }),
       );
+
       const authController = new AuthController(authService);
       const res = await authController.signUpByMaster(master, body);
       expect(res).toStrictEqual(createdAdmin);


### PR DESCRIPTION
## 개요

- admin본인이 email, password, nickname을 제외한 정보를 변경할 수 있다.
- 물론 gradeId는 변경이 불가하다.

## ✅ 작업 내용

- modifyAdminInfo function in AdminController
- modifyAdminInfo test

## 🔨 변경 로직


## 🧨 관련 이슈

- #8 
- typia.random이 key를 as로 리턴한 타입에는 typia comment가 적용 안되는 에러 확인
- https://github.com/samchon/typia/issues/667
