### PR TITLE
Docs : admin controller swagger

### DIFF
--- a/server/nestia.config.ts
+++ b/server/nestia.config.ts
@@ -5,7 +5,7 @@ const NESTIA_CONFIG: sdk.INestiaConfig = {
   /**
    * List of files or directories containing the NestJS controller classes.
    */
-  input: 'src/domain/**/*.controller.ts',
+  input: 'src/**/*.controller.ts',
   /**
    * Output directory that SDK would be placed in.
    *
@@ -39,7 +39,13 @@ const NESTIA_CONFIG: sdk.INestiaConfig = {
     /**
      * Security schemes.
      */
-    security: {},
+    security: {
+      bearer: {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'Authorization',
+      },
+    },
   },
   /**
    * Whether to wrap DTO by primitive type.

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -16,6 +16,7 @@
         "@nestjs/jwt": "^10.0.3",
         "@nestjs/passport": "^9.0.3",
         "@nestjs/platform-express": "^9.0.0",
+        "@nestjs/swagger": "^7.0.1",
         "@prisma/client": "^4.14.1",
         "@types/bcrypt": "^5.0.0",
         "bcrypt": "^5.1.0",
@@ -1830,6 +1831,25 @@
         "@nestjs/common": "^8.0.0 || ^9.0.0"
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.0.0.tgz",
+      "integrity": "sha512-JyIOY1OE4x2t8Z2ImWLQJnHVqLCBHJZXm6RqcOG3+4rIsqMQxm5smHbb7H5C6tLAdDcRYd/fG2gYK1J1GiqKLw==",
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/passport": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/@nestjs/passport/-/passport-9.0.3.tgz",
@@ -1904,6 +1924,37 @@
       },
       "peerDependencies": {
         "typescript": ">=4.3.5"
+      }
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-7.0.1.tgz",
+      "integrity": "sha512-V5W03kPSQUFZDvf+SixijuH1/IZBO0RInh9n6CV8WAd9jzteJBMh8mQ/FK6RB9Rf8EApUv2foCM2ZuSUxw7h0A==",
+      "dependencies": {
+        "@nestjs/mapped-types": "2.0.0",
+        "js-yaml": "4.1.0",
+        "lodash": "4.17.21",
+        "path-to-regexp": "3.2.0",
+        "swagger-ui-dist": "4.19.0"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^6.0.0",
+        "@nestjs/common": "^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^9.0.0 || ^10.0.0",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nestjs/testing": {
@@ -2955,8 +3006,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -6132,7 +6182,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -8259,6 +8308,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.19.0.tgz",
+      "integrity": "sha512-9C9fJGI18gK5AhaU5YRyPY1lXJH4lmWh8h9zFMrJBkYzdRjCbAzYl1ayWPYgwFvag/Luqi3Co599OK/39IS2QQ=="
     },
     "node_modules/symbol-observable": {
       "version": "4.0.0",
@@ -10701,6 +10755,12 @@
         "jsonwebtoken": "9.0.0"
       }
     },
+    "@nestjs/mapped-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.0.0.tgz",
+      "integrity": "sha512-JyIOY1OE4x2t8Z2ImWLQJnHVqLCBHJZXm6RqcOG3+4rIsqMQxm5smHbb7H5C6tLAdDcRYd/fG2gYK1J1GiqKLw==",
+      "requires": {}
+    },
     "@nestjs/passport": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/@nestjs/passport/-/passport-9.0.3.tgz",
@@ -10743,6 +10803,18 @@
         "@angular-devkit/schematics": "16.0.1",
         "jsonc-parser": "3.2.0",
         "pluralize": "8.0.0"
+      }
+    },
+    "@nestjs/swagger": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-7.0.1.tgz",
+      "integrity": "sha512-V5W03kPSQUFZDvf+SixijuH1/IZBO0RInh9n6CV8WAd9jzteJBMh8mQ/FK6RB9Rf8EApUv2foCM2ZuSUxw7h0A==",
+      "requires": {
+        "@nestjs/mapped-types": "2.0.0",
+        "js-yaml": "4.1.0",
+        "lodash": "4.17.21",
+        "path-to-regexp": "3.2.0",
+        "swagger-ui-dist": "4.19.0"
       }
     },
     "@nestjs/testing": {
@@ -11595,8 +11667,7 @@
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "array-flatten": {
       "version": "1.1.1",
@@ -13994,7 +14065,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "requires": {
         "argparse": "^2.0.1"
       }
@@ -15584,6 +15654,11 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
+    },
+    "swagger-ui-dist": {
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.19.0.tgz",
+      "integrity": "sha512-9C9fJGI18gK5AhaU5YRyPY1lXJH4lmWh8h9zFMrJBkYzdRjCbAzYl1ayWPYgwFvag/Luqi3Co599OK/39IS2QQ=="
     },
     "symbol-observable": {
       "version": "4.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -29,6 +29,7 @@
     "@nestjs/jwt": "^10.0.3",
     "@nestjs/passport": "^9.0.3",
     "@nestjs/platform-express": "^9.0.0",
+    "@nestjs/swagger": "^7.0.1",
     "@prisma/client": "^4.14.1",
     "@types/bcrypt": "^5.0.0",
     "bcrypt": "^5.1.0",

--- a/server/src/auth/auth.controller.ts
+++ b/server/src/auth/auth.controller.ts
@@ -8,7 +8,10 @@ import { AuthService } from './auth.service';
 import { TypedBody, TypedRoute } from '@nestia/core';
 import { AdminGuard } from './guards/admin.guard';
 import { User } from 'src/common/decorators/user.decorator';
-import { AdminLogInDto } from 'src/database/dtos/auth/admin-login.dto';
+import {
+  AdminLogInDto,
+  AdminLogInInputDto,
+} from 'src/database/dtos/auth/admin-login.dto';
 import { AdminSignUpInputDto } from 'src/database/dtos/admin/admin.inbound-port.dto';
 import { FindOneAdminExceptPasswordDto } from 'src/database/dtos/admin/admin.outbound-port.dto';
 import { ADMIN_GRADE } from 'src/database/values/admin-grade.value';
@@ -20,7 +23,10 @@ export class AuthController {
 
   @UseGuards(AdminGuard)
   @TypedRoute.Post('admin-login')
-  async adminSignIn(@User() user: AdminLogInDto): Promise<{
+  async adminSignIn(
+    @User() user: AdminLogInDto,
+    @TypedBody() body: AdminLogInInputDto,
+  ): Promise<{
     accessToken: string;
   }> {
     const token = await this.authService.adminSignIn(user);

--- a/server/src/auth/auth.controller.ts
+++ b/server/src/auth/auth.controller.ts
@@ -21,6 +21,9 @@ import { JwtMasterAdminGuard } from './guards/jwt-master-admin.guard';
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
+  /**
+   * @tag Auth
+   */
   @UseGuards(AdminGuard)
   @TypedRoute.Post('admin-login')
   async adminSignIn(
@@ -41,6 +44,9 @@ export class AuthController {
   //   return this.authService.adminSignUp(adminInfo);
   // }
 
+  /**
+   * @tag Auth
+   */
   @UseGuards(JwtMasterAdminGuard)
   @TypedRoute.Post('sign-up-by-master')
   async signUpByMaster(

--- a/server/src/config/swagger.config.ts
+++ b/server/src/config/swagger.config.ts
@@ -1,0 +1,13 @@
+import { INestApplication } from '@nestjs/common';
+import { SwaggerModule } from '@nestjs/swagger';
+import * as fs from 'fs';
+import * as path from 'path';
+
+export function swaggerSetUp(app: INestApplication) {
+  const docs = fs.readFileSync(
+    path.join(__dirname, '../../swagger.json'),
+    'utf-8',
+  );
+
+  SwaggerModule.setup('api-docs', app, JSON.parse(docs));
+}

--- a/server/src/database/dtos/admin/admin.outbound-port.dto.ts
+++ b/server/src/database/dtos/admin/admin.outbound-port.dto.ts
@@ -11,7 +11,6 @@ export interface FindAdminInfoForCommonDto
   mainPostings: MainPostingEntity.MainPosting[];
 }
 
-export type FindAdminForListForCommonDto = Omit<
-  FindAdminInfoForCommonDto,
-  'mainPostings'
->;
+export type FindAdminForListForCommonDto = {
+  admins: Omit<FindAdminInfoForCommonDto, 'mainPostings'>[];
+};

--- a/server/src/database/dtos/auth/admin-login.dto.ts
+++ b/server/src/database/dtos/auth/admin-login.dto.ts
@@ -19,3 +19,5 @@ export interface AdminJwtDto extends AdminLogInDto {
    */
   exp: number;
 }
+
+export type AdminLogInInputDto = Pick<AdminEntity.Admin, 'email' | 'password'>;

--- a/server/src/database/dtos/select/admin-select.dto.ts
+++ b/server/src/database/dtos/select/admin-select.dto.ts
@@ -10,3 +10,8 @@ export type SelectFindOneAdminExceptPasswordDto = {
 export type SelectFindAdminInfoForCommonDto = {
   [P in keyof FindAdminInfoForCommonDto as `${P}`]: FindAdminInfoForCommonDto[P];
 };
+
+export type SelectFindAdminForListForCommonDto = Omit<
+  FindAdminInfoForCommonDto,
+  'mainPostings'
+>;

--- a/server/src/database/models/admin/admin.entity.ts
+++ b/server/src/database/models/admin/admin.entity.ts
@@ -25,7 +25,7 @@ export namespace AdminEntity {
     introduction: string | null;
 
     /**
-     * @format date
+     * @format date-time
      */
     birth: string;
 

--- a/server/src/database/prisma/schema.prisma
+++ b/server/src/database/prisma/schema.prisma
@@ -19,7 +19,7 @@ model Admin {
   lastName String
   nickname String @unique
   introduction String? @db.Text
-  birth DateTime @db.Date /// @format date
+  birth DateTime @db.Date /// @format date-time
   
   emailReception Boolean
 

--- a/server/src/database/repositories/admin.repository.ts
+++ b/server/src/database/repositories/admin.repository.ts
@@ -20,6 +20,7 @@ import {
 import { dateAndBigIntToString } from 'src/utils/functions/date-and-bigint-to-string.function';
 import { AdminEntity } from '../models/admin/admin.entity';
 import {
+  SelectFindAdminForListForCommonDto,
   SelectFindAdminInfoForCommonDto,
   SelectFindOneAdminExceptPasswordDto,
 } from '../dtos/select/admin-select.dto';
@@ -74,15 +75,15 @@ export class AdminRepository implements AdminRepositoryOutboundPort {
   }
 
   async findAdminList(
-    options: Partial<
-      Pick<AdminEntity.Admin, 'email' | 'nickname' | 'gradeId' | 'id'>
-    >,
-  ): Promise<FindAdminForListForCommonDto[] | null> {
+    options: AdminOptionsDto,
+  ): Promise<FindAdminForListForCommonDto | null> {
     const admins = await this.prisma.admin.findMany({
-      select: typia.random<TypeToSelect<FindAdminForListForCommonDto>>(),
+      select: typia.random<TypeToSelect<SelectFindAdminForListForCommonDto>>(),
     });
 
-    return dateAndBigIntToString(admins);
+    const res = { admins };
+
+    return dateAndBigIntToString(res);
   }
 
   async updateAdmin(

--- a/server/src/database/repositories/outbound-ports/admin-repository.outbound-port.ts
+++ b/server/src/database/repositories/outbound-ports/admin-repository.outbound-port.ts
@@ -35,5 +35,5 @@ export interface AdminRepositoryOutboundPort {
 
   findAdminList(
     options: AdminOptionsDto,
-  ): Promise<FindAdminForListForCommonDto[] | null>;
+  ): Promise<FindAdminForListForCommonDto | null>;
 }

--- a/server/src/domain/admin/admin.controller.ts
+++ b/server/src/domain/admin/admin.controller.ts
@@ -20,6 +20,9 @@ import {
 export class AdminController {
   constructor(private readonly adminService: AdminService) {}
 
+  /**
+   * @tag Admin
+   */
   @TypedRoute.Get('list')
   async getAdminList(): Promise<FindAdminForListForCommonDto> {
     const admins = await this.adminService.getAdminList({});
@@ -27,6 +30,9 @@ export class AdminController {
     return admins;
   }
 
+  /**
+   * @tag Admin
+   */
   @UseGuards(JwtAdminGuard)
   @TypedRoute.Get(':id')
   async getAdminInfoForSelf(
@@ -42,6 +48,9 @@ export class AdminController {
     return admin;
   }
 
+  /**
+   * @tag Admin
+   */
   @TypedRoute.Get(':id/info')
   async getAdminInfoForCommon(
     @TypedParam('id') id: number,
@@ -51,6 +60,9 @@ export class AdminController {
     return admin;
   }
 
+  /**
+   * @tag Admin
+   */
   @UseGuards(JwtAdminGuard)
   @TypedRoute.Put(':id/password')
   async modifyPassword(
@@ -69,6 +81,9 @@ export class AdminController {
     return admin;
   }
 
+  /**
+   * @tag Admin
+   */
   @UseGuards(JwtAdminGuard)
   @TypedRoute.Put(':id/nickname')
   async modifyNickname(
@@ -87,6 +102,9 @@ export class AdminController {
     return admin;
   }
 
+  /**
+   * @tag Admin
+   */
   @UseGuards(JwtAdminGuard)
   @TypedRoute.Put(':id/email')
   async modifyEmail(
@@ -105,6 +123,9 @@ export class AdminController {
     return admin;
   }
 
+  /**
+   * @tag Admin
+   */
   @UseGuards(JwtAdminGuard)
   @TypedRoute.Put(':id')
   async modifyAdminInfo(

--- a/server/src/domain/admin/admin.controller.ts
+++ b/server/src/domain/admin/admin.controller.ts
@@ -21,10 +21,10 @@ export class AdminController {
   constructor(private readonly adminService: AdminService) {}
 
   @TypedRoute.Get('list')
-  async getAdminList(): Promise<{ admins: FindAdminForListForCommonDto[] }> {
+  async getAdminList(): Promise<FindAdminForListForCommonDto> {
     const admins = await this.adminService.getAdminList({});
 
-    return { admins };
+    return admins;
   }
 
   @UseGuards(JwtAdminGuard)

--- a/server/src/domain/admin/admin.controller.ts
+++ b/server/src/domain/admin/admin.controller.ts
@@ -20,6 +20,13 @@ import {
 export class AdminController {
   constructor(private readonly adminService: AdminService) {}
 
+  @TypedRoute.Get('list')
+  async getAdminList(): Promise<{ admins: FindAdminForListForCommonDto[] }> {
+    const admins = await this.adminService.getAdminList({});
+
+    return { admins };
+  }
+
   @UseGuards(JwtAdminGuard)
   @TypedRoute.Get(':id')
   async getAdminInfoForSelf(
@@ -42,13 +49,6 @@ export class AdminController {
     const admin = await this.adminService.getAdminInfoForCommon({ id });
 
     return admin;
-  }
-
-  @TypedRoute.Get('list')
-  async getAdminList(): Promise<FindAdminForListForCommonDto[]> {
-    const admins = await this.adminService.getAdminList({});
-
-    return admins;
   }
 
   @UseGuards(JwtAdminGuard)

--- a/server/src/domain/admin/admin.service.ts
+++ b/server/src/domain/admin/admin.service.ts
@@ -46,7 +46,7 @@ export class AdminService {
 
   async getAdminList(
     options: AdminOptionsDto,
-  ): Promise<FindAdminForListForCommonDto[]> {
+  ): Promise<FindAdminForListForCommonDto> {
     const admins = await this.adminRepo.findAdminList(options);
 
     if (!admins) {

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -1,12 +1,17 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { PrismaService } from 'src/database/prisma/prisma.service';
+import { swaggerSetUp } from './config/swagger.config';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
   const prismaService = app.get(PrismaService);
   await prismaService.enableShutdownHooks(app);
+
+  swaggerSetUp(app);
+
+  app.enableCors();
 
   await app.listen(3000);
 }

--- a/server/src/test/unit/admin.spec.ts
+++ b/server/src/test/unit/admin.spec.ts
@@ -15,7 +15,6 @@ import { AdminController } from 'src/domain/admin/admin.controller';
 import { AdminService } from 'src/domain/admin/admin.service';
 import typia from 'typia';
 import { MockAdminRepository } from './mock/admin.repository.mock';
-import { OmitAmongObject } from 'src/utils/types/omit-among-object.type';
 
 describe('Admin Spec', () => {
   describe('1. Validate Admin', () => {
@@ -30,7 +29,10 @@ describe('Admin Spec', () => {
       );
       const authController = new AuthController(authService);
 
-      const res = await authController.adminSignIn(user);
+      const res = await authController.adminSignIn(user, {
+        email: 'test@gmail.com',
+        password: '1234',
+      });
 
       expect(res.accessToken).toBeDefined();
     });
@@ -153,7 +155,7 @@ describe('Admin Spec', () => {
     it('4-1. 어드민 목록을 불러옵니다.', async () => {
       const createAdmin = typia.createRandom<FindAdminForListForCommonDto>();
 
-      const admins = [createAdmin(), createAdmin(), createAdmin()];
+      const admins = createAdmin();
 
       const adminService = new AdminService(
         new MockAdminRepository({

--- a/server/src/test/unit/mock/admin.repository.mock.ts
+++ b/server/src/test/unit/mock/admin.repository.mock.ts
@@ -9,9 +9,7 @@ import {
   FindOneAdminExceptPasswordDto,
 } from 'src/database/dtos/admin/admin.outbound-port.dto';
 import { AdminEntity } from 'src/database/models/admin/admin.entity';
-import { CommonDateEntity } from 'src/database/models/common/common-date.entity';
 import { AdminRepositoryOutboundPort } from 'src/database/repositories/outbound-ports/admin-repository.outbound-port';
-import { OmitAmongObject } from 'src/utils/types/omit-among-object.type';
 
 /**
  * 동일한 repository 함수를 두 번 호출할 경우, 결과 값을 1개만 쓸수 밖에 없다는 단점이 있다.
@@ -76,7 +74,7 @@ export class MockAdminRepository implements AdminRepositoryOutboundPort {
 
   async findAdminList(
     options: AdminOptionsDto,
-  ): Promise<FindAdminForListForCommonDto[] | null> {
+  ): Promise<FindAdminForListForCommonDto | null> {
     const res = this.result.findAdminList?.pop();
     if (res === undefined) {
       throw new Error('undefined');

--- a/server/src/utils/functions/date-and-bigint-to-string.function.ts
+++ b/server/src/utils/functions/date-and-bigint-to-string.function.ts
@@ -7,6 +7,10 @@ export function dateAndBigIntToString<T extends object>(
     return null;
   }
 
+  if (target instanceof Array) {
+    return target;
+  }
+
   try {
     const res = Object.entries(target).reduce((acc, [key, value]) => {
       if (value === null) {


### PR DESCRIPTION
## 개요

- nestia의 swagger 자동생성 기능을 사용할 수 있다.
- `npx nestia swagger`를 이용하면 dist폴더에 `swagger.json` 파일이 생성된다.

## ✅ 작업 내용

- `nestia.config.ts` 파일에서 swagger관련 옵션 설정
- swagger set up
- `@nestjs/swagger` 패키지 설치
- 컨트롤러의 함수에 swagger tag 추가.

## 🔨 변경 로직

- Admin의 birth칼럼의 validation comment를 date에서 date-time으로 수정
- dateAndBigIntToString 함수에 Array분기 처리 추가
- AdminLogInInputDto를 signIn 함수에 추가
- getAdminList함수의 순서 변경 (url 경로 이슈)
- FindAdminForListForCommonDto가 객체타입이 되도록 수정
- findAdminList test 수정

## 🧨 관련 이슈

close #8 
