### PR TITLE
Feat : get category list

### DIFF
--- a/server/src/database/dtos/main-posting-category/main-posting-category.outbount-port.dto.ts
+++ b/server/src/database/dtos/main-posting-category/main-posting-category.outbount-port.dto.ts
@@ -17,6 +17,12 @@ export type FindCategoryListDto = {
   categories: MainPostingCategoryEntity[];
 };
 
+export type FindAllCategoriesDto = {
+  categories: (MainPostingCategoryEntity & {
+    childs: MainPostingCategoryEntity[];
+  })[];
+};
+
 export type SaveChangesMainPostingCategoryInputDto = Partial<{
   create: Array<Omit<MainPostingCategoryEntity, 'id'>>;
   update: Array<MainPostingCategoryEntity>;

--- a/server/src/database/prisma/schema.prisma
+++ b/server/src/database/prisma/schema.prisma
@@ -73,6 +73,9 @@ model MainPostingCategory {
 
   parentId Int? /// @type int
 
+  parent MainPostingCategory? @relation("ParentChilds", fields: [parentId], references: [id])
+  childs MainPostingCategory[] @relation("ParentChilds")
+
   mainPostings MainPosting[]
 }
 

--- a/server/src/database/repositories/main-posting-category.repository.ts
+++ b/server/src/database/repositories/main-posting-category.repository.ts
@@ -4,6 +4,7 @@ import { MainPostingCategoryRepositoryOutbountPort } from './outbound-ports/main
 import {
   CreateMainPostingCategoriesInputDto,
   CreateManyMainPostingCategoryOutputDto,
+  FindAllCategoriesDto,
   FindCategoryListDto,
   SaveChangesMainPostingCategoryInputDto,
   SaveChangesMainPostingCategoryOutputDto,
@@ -16,6 +17,7 @@ export class MainPostingCategoryRepository
   implements MainPostingCategoryRepositoryOutbountPort
 {
   constructor(private readonly prisma: PrismaService) {}
+
   // 해당 함수를 사용하기 전에, parentId인 category의 parentId가 null인지 확인해야한다.
   async saveChanges(
     input: SaveChangesMainPostingCategoryInputDto,
@@ -137,6 +139,19 @@ export class MainPostingCategoryRepository
     });
 
     return category;
+  }
+
+  async findAllCategories(): Promise<FindAllCategoriesDto | null> {
+    const categories = await this.prisma.mainPostingCategory.findMany({
+      where: {
+        parentId: null,
+      },
+      include: {
+        childs: true,
+      },
+    });
+
+    return { categories };
   }
 
   async updateCategory(

--- a/server/src/database/repositories/outbound-ports/main-posting-category-repository.outbound-port.ts
+++ b/server/src/database/repositories/outbound-ports/main-posting-category-repository.outbound-port.ts
@@ -2,6 +2,7 @@ import { IsDeletedOutputDto } from 'src/database/dtos/common/crud-bool.dto';
 import {
   CreateMainPostingCategoriesInputDto,
   CreateManyMainPostingCategoryOutputDto,
+  FindAllCategoriesDto,
   FindCategoryListDto,
   SaveChangesMainPostingCategoryInputDto,
   SaveChangesMainPostingCategoryOutputDto,
@@ -27,6 +28,8 @@ export interface MainPostingCategoryRepositoryOutbountPort {
   ): Promise<CreateManyMainPostingCategoryOutputDto | null>;
 
   findCategory(categoryId: number): Promise<MainPostingCategoryEntity | null>;
+
+  findAllCategories(): Promise<FindAllCategoriesDto | null>;
 
   updateCategory(
     data: MainPostingCategoryEntity,

--- a/server/src/domain/main-posting-catogory/main-posting-category.controller.ts
+++ b/server/src/domain/main-posting-catogory/main-posting-category.controller.ts
@@ -6,6 +6,7 @@ import { User } from 'src/common/decorators/user.decorator';
 import { AdminLogInDto } from 'src/database/dtos/auth/admin-login.dto';
 import { ADMIN_GRADE } from 'src/database/values/admin-grade.value';
 import {
+  FindAllCategoriesDto,
   SaveChangesMainPostingCategoryInputDto,
   SaveChangesMainPostingCategoryOutputDto,
 } from 'src/database/dtos/main-posting-category/main-posting-category.outbount-port.dto';
@@ -15,6 +16,20 @@ export class MainPostingCategoryController {
   constructor(
     private readonly mainPostingCategoryService: MainPostingCategoryService,
   ) {}
+
+  @UseGuards(JwtMasterAdminGuard)
+  @TypedRoute.Get('list')
+  async getAllCategories(
+    @User() user: AdminLogInDto,
+  ): Promise<FindAllCategoriesDto> {
+    if (user.gradeId !== ADMIN_GRADE.master) {
+      throw new UnauthorizedException('UnAuthorized');
+    }
+
+    const categories = await this.mainPostingCategoryService.getAllCategories();
+
+    return categories;
+  }
 
   @UseGuards(JwtMasterAdminGuard)
   @TypedRoute.Put()

--- a/server/src/domain/main-posting-catogory/main-posting-category.service.ts
+++ b/server/src/domain/main-posting-catogory/main-posting-category.service.ts
@@ -1,5 +1,6 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 import {
+  FindAllCategoriesDto,
   SaveChangesMainPostingCategoryInputDto,
   SaveChangesMainPostingCategoryOutputDto,
 } from 'src/database/dtos/main-posting-category/main-posting-category.outbount-port.dto';
@@ -21,5 +22,15 @@ export class MainPostingCategoryService {
     const res = this.mainPostingCategoryRepo.saveChanges(data);
 
     return res;
+  }
+
+  async getAllCategories(): Promise<FindAllCategoriesDto> {
+    const categories = await this.mainPostingCategoryRepo.findAllCategories();
+
+    if (!categories) {
+      throw new NotFoundException('no categories');
+    }
+
+    return categories;
   }
 }

--- a/server/src/test/unit/main-posting-category.spec.ts
+++ b/server/src/test/unit/main-posting-category.spec.ts
@@ -3,6 +3,7 @@ import { MockMainPostingCategoryRepository } from './mock/main-posting-category.
 import { MainPostingCategoryController } from 'src/domain/main-posting-catogory/main-posting-category.controller';
 import typia from 'typia';
 import {
+  FindAllCategoriesDto,
   SaveChangesMainPostingCategoryInputDto,
   SaveChangesMainPostingCategoryOutputDto,
 } from 'src/database/dtos/main-posting-category/main-posting-category.outbount-port.dto';
@@ -47,6 +48,29 @@ describe('MainPostingCategory Spec', () => {
   });
 
   describe('2. Read Category List', () => {
-    it.todo('2-1. 카테고리 목록을 불러옵니다.');
+    it('2-1. 카테고리 목록을 불러옵니다.', async () => {
+      const user: AdminLogInDto = {
+        id: 1,
+        gradeId: 1,
+        email: 'test@gmail.com',
+        nickname: 'sloth',
+      };
+
+      const categories = typia.random<FindAllCategoriesDto>();
+
+      const mainPostingCategoryService = new MainPostingCategoryService(
+        new MockMainPostingCategoryRepository({
+          findAllCategories: [categories],
+        }),
+      );
+
+      const mainPostingCategoryController = new MainPostingCategoryController(
+        mainPostingCategoryService,
+      );
+
+      const res = await mainPostingCategoryController.getAllCategories(user);
+
+      expect(res).toStrictEqual(categories);
+    });
   });
 });

--- a/server/src/test/unit/mock/main-posting-category.repository.mock.ts
+++ b/server/src/test/unit/mock/main-posting-category.repository.mock.ts
@@ -5,6 +5,7 @@ import {
   CreateManyMainPostingCategoryOutputDto,
   FindCategoryListDto,
   SaveChangesMainPostingCategoryInputDto,
+  FindAllCategoriesDto,
 } from 'src/database/dtos/main-posting-category/main-posting-category.outbount-port.dto';
 import { MainPostingCategoryEntity } from 'src/database/models/main-posting/main-posting-category.entity';
 import { MainPostingCategoryRepositoryOutbountPort } from 'src/database/repositories/outbound-ports/main-posting-category-repository.outbound-port';
@@ -46,6 +47,14 @@ export class MockMainPostingCategoryRepository
     categoryId: number,
   ): Promise<MainPostingCategoryEntity | null> {
     const res = this.result.findCategory?.pop();
+    if (res === undefined) {
+      throw new Error('undefined');
+    }
+    return res;
+  }
+
+  async findAllCategories(): Promise<FindAllCategoriesDto | null> {
+    const res = this.result.findAllCategories?.pop();
     if (res === undefined) {
       throw new Error('undefined');
     }


### PR DESCRIPTION
## 개요

- masteb admin이 카테고리 수정을 위해 카테고리 목록을 불러올 수 있다.

## ✅ 작업 내용

- findAllCategories in MainPostingCategoryRepository
- getAllCategories in MainPostingCategoryService
- getAllCategories in MainPostingCategoryController
- get all categories test

## 🔨 변경 로직

- `prisma.schem`에서 MainPostingCategory가 자기 자신을 1:n으로 참조하도록 설정

## 🧨 관련 이슈

- #24 
