### PR TITLE
Feat : remove main posting

### DIFF
--- a/server/src/database/dtos/common/crud-bool.dto.ts
+++ b/server/src/database/dtos/common/crud-bool.dto.ts
@@ -1,15 +1,15 @@
 export type IsCreatedOutputDto = {
-  created: boolean;
+  isCreated: boolean;
 };
 
 export type IsReadOutputDto = {
-  read: boolean;
+  isRead: boolean;
 };
 
 export type IsUpdatedOutputDto = {
-  updated: boolean;
+  isUpdated: boolean;
 };
 
 export type IsDeletedOutputDto = {
-  deleted: boolean;
+  isDeleted: boolean;
 };

--- a/server/src/database/repositories/main-posting-category.repository.ts
+++ b/server/src/database/repositories/main-posting-category.repository.ts
@@ -189,21 +189,21 @@ export class MainPostingCategoryRepository
     });
 
     if (!category) {
-      return { deleted: false };
+      return { isDeleted: false };
     }
 
-    return { deleted: true };
+    return { isDeleted: true };
   }
 
   async deleteCategories(categoryIds: number[]): Promise<IsDeletedOutputDto> {
     for (const categoryId of categoryIds) {
       const res = await this.deleteCategory(categoryId);
 
-      if (res.deleted === false) {
+      if (res.isDeleted === false) {
         throw new BadRequestException('Incorrect option');
       }
     }
 
-    return { deleted: true };
+    return { isDeleted: true };
   }
 }

--- a/server/src/database/repositories/outbound-ports/main-posting-repository.outbound-port.ts
+++ b/server/src/database/repositories/outbound-ports/main-posting-repository.outbound-port.ts
@@ -1,3 +1,4 @@
+import { IsDeletedOutputDto } from 'src/database/dtos/common/crud-bool.dto';
 import {
   CreateMainPostingInputDto,
   FindMainPostingOptionsDto,
@@ -21,4 +22,9 @@ export interface MainPostingRepositoryOutboundPort {
     id: string,
     data: CreateMainPostingInputDto,
   ): Promise<MainPostingEntity.MainPosting | null>;
+
+  deleteMainPosting(
+    mainPostingId: string,
+    adminId: number,
+  ): Promise<IsDeletedOutputDto | null>;
 }

--- a/server/src/domain/main-posting/main-posting.controller.ts
+++ b/server/src/domain/main-posting/main-posting.controller.ts
@@ -5,6 +5,7 @@ import { JwtAdminGuard } from 'src/auth/guards/jwt-admin.guard';
 import { User } from 'src/common/decorators/user.decorator';
 import { AdminLogInDto } from 'src/database/dtos/auth/admin-login.dto';
 import { CreateMainPostingInputDto } from 'src/database/dtos/main-posting/main-posting.outbound-port.dto';
+import { IsDeletedOutputDto } from 'src/database/dtos/common/crud-bool.dto';
 
 @Controller('api/v1/main-posting')
 export class MainPostingController {
@@ -42,5 +43,19 @@ export class MainPostingController {
     );
 
     return mainPosting;
+  }
+
+  @UseGuards(JwtAdminGuard)
+  @TypedRoute.Delete(':id')
+  async removeMainPosting(
+    @TypedParam('id') id: string,
+    @User() user: AdminLogInDto,
+  ): Promise<IsDeletedOutputDto> {
+    const isDeleted = await this.mainPostingService.removeMainPosting(
+      id,
+      user.id,
+    );
+
+    return isDeleted;
   }
 }

--- a/server/src/domain/main-posting/main-posting.controller.ts
+++ b/server/src/domain/main-posting/main-posting.controller.ts
@@ -6,6 +6,7 @@ import { User } from 'src/common/decorators/user.decorator';
 import { AdminLogInDto } from 'src/database/dtos/auth/admin-login.dto';
 import { CreateMainPostingInputDto } from 'src/database/dtos/main-posting/main-posting.outbound-port.dto';
 import { IsDeletedOutputDto } from 'src/database/dtos/common/crud-bool.dto';
+import { MainPostingEntity } from 'src/database/models/main-posting/main-posting.entity';
 
 @Controller('api/v1/main-posting')
 export class MainPostingController {
@@ -33,7 +34,7 @@ export class MainPostingController {
     @TypedBody() body: CreateMainPostingInputDto,
     @TypedParam('id') id: string,
     @User() user: AdminLogInDto,
-  ) {
+  ): Promise<MainPostingEntity.MainPosting> {
     const mainPosting = await this.mainPostingService.modifyMainPosting(
       id,
       user.id,

--- a/server/src/domain/main-posting/main-posting.service.ts
+++ b/server/src/domain/main-posting/main-posting.service.ts
@@ -4,6 +4,7 @@ import {
   Injectable,
   UnauthorizedException,
 } from '@nestjs/common';
+import { IsDeletedOutputDto } from 'src/database/dtos/common/crud-bool.dto';
 import { CreateMainPostingInputDto } from 'src/database/dtos/main-posting/main-posting.outbound-port.dto';
 import { MainPostingEntity } from 'src/database/models/main-posting/main-posting.entity';
 import {
@@ -58,5 +59,21 @@ export class MainPostingService {
     }
 
     return mainPosting;
+  }
+
+  async removeMainPosting(
+    mainPostingId: string,
+    adminId: number,
+  ): Promise<IsDeletedOutputDto> {
+    const isDeleted = await this.mainPostingRepo.deleteMainPosting(
+      mainPostingId,
+      adminId,
+    );
+
+    if (!isDeleted) {
+      throw new UnauthorizedException('UnAuthorized');
+    }
+
+    return isDeleted;
   }
 }

--- a/server/src/test/unit/main-posting.spec.ts
+++ b/server/src/test/unit/main-posting.spec.ts
@@ -81,7 +81,34 @@ describe('MainPosting Spec', () => {
   });
 
   describe('4. Delete MainPosting', () => {
-    it.todo('4-1. 메인포스팅을 삭제합니다.');
+    it('4-1. 메인포스팅을 삭제합니다.', async () => {
+      const user: AdminLogInDto = {
+        id: 1,
+        gradeId: 1,
+        email: 'test@gmail.com',
+        nickname: 'sloth',
+      };
+
+      const mainPostingService = new MainPostingService(
+        new MockMainPostingRepository({
+          deleteMainPosting: [
+            {
+              isDeleted: true,
+            },
+          ],
+        }),
+      );
+
+      const mainPostingController = new MainPostingController(
+        mainPostingService,
+      );
+
+      const res = await mainPostingController.removeMainPosting('1', user);
+
+      expect(res).toStrictEqual({
+        isDeleted: true,
+      });
+    });
   });
 
   describe('5. Read MainPosting List', () => {

--- a/server/src/test/unit/mock/main-posting.repository.mock.ts
+++ b/server/src/test/unit/mock/main-posting.repository.mock.ts
@@ -1,3 +1,4 @@
+import { IsDeletedOutputDto } from 'src/database/dtos/common/crud-bool.dto';
 import {
   CreateMainPostingInputDto,
   FindMainPostingOptionsDto,
@@ -47,6 +48,19 @@ export class MockMainPostingRepository
     data: CreateMainPostingInputDto,
   ): Promise<MainPostingEntity.MainPosting | null> {
     const res = await this.result.updateMainPosting?.pop();
+
+    if (res === undefined) {
+      throw new Error('undefined');
+    }
+
+    return res;
+  }
+
+  async deleteMainPosting(
+    mainPostingId: string,
+    adminId: number,
+  ): Promise<IsDeletedOutputDto | null> {
+    const res = await this.result.deleteMainPosting?.pop();
 
     if (res === undefined) {
       throw new Error('undefined');


### PR DESCRIPTION
## 개요

- admin이 메인 포스팅을 삭제할 수 있다.

## ✅ 작업 내용

- deleteMainPosting in MainPostingRepository
- removeMainPosting in MainPostingController
- removeMainPosting in MainPostingService
- delete main posting test

## 🔨 변경 로직

- CRUD BOOL Type
- add return type to modifyMainPosting in MainPostingController

## 🧨 관련 이슈

- #22 