### PR TITLE
Feat : get main posting list

### DIFF
--- a/server/src/database/dtos/common/select/main-posting-select.dto.ts
+++ b/server/src/database/dtos/common/select/main-posting-select.dto.ts
@@ -1,0 +1,5 @@
+import { FindMainPostingListOutputDto } from '../../main-posting/main-posting.outbound-port.dto';
+
+export type SelectFindMainPostingListDto = {
+  [P in keyof FindMainPostingListOutputDto['mainPostings'][0] as `${P}`]: FindMainPostingListOutputDto['mainPostings'][0][P];
+};

--- a/server/src/database/dtos/main-posting/main-posting.inbound-port.dto.ts
+++ b/server/src/database/dtos/main-posting/main-posting.inbound-port.dto.ts
@@ -1,0 +1,20 @@
+import { FindMainPostingListOptionsForPagenationDto } from './main-posting.outbound-port.dto';
+
+export type MainPostingPagenationQueryInputDto = Pick<
+  FindMainPostingListOptionsForPagenationDto,
+  'countPerPage' | 'pageNumber'
+> & {
+  /**
+   * @type int
+   */
+  adminId?: number;
+
+  /**
+   * @type int
+   */
+  categoryId?: number;
+
+  orderType?: 'createdAt';
+
+  order?: 'desc' | 'asc';
+};

--- a/server/src/database/dtos/main-posting/main-posting.outbound-port.dto.ts
+++ b/server/src/database/dtos/main-posting/main-posting.outbound-port.dto.ts
@@ -8,3 +8,31 @@ export type CreateMainPostingInputDto = Pick<
 export type FindMainPostingOptionsDto = Partial<
   Pick<MainPostingEntity.MainPosting, 'id' | 'adminId' | 'categoryId'>
 >;
+
+export type FindMainPostingListOutputDto = {
+  mainPostings: Pick<
+    MainPostingEntity.MainPosting,
+    'id' | 'adminId' | 'categoryId' | 'title' | 'createdAt'
+  >[];
+};
+
+export type FindMainPostingListOptionsForPagenationDto = {
+  options?: Partial<
+    Pick<MainPostingEntity.MainPosting, 'adminId' | 'categoryId'>
+  >;
+
+  order?: {
+    type: 'createdAt';
+    order: 'desc' | 'asc';
+  };
+
+  /**
+   * @type int
+   */
+  pageNumber: number;
+
+  /**
+   * @type int
+   */
+  countPerPage: number;
+};

--- a/server/src/database/models/main-posting/main-posting-report.entity.ts
+++ b/server/src/database/models/main-posting/main-posting-report.entity.ts
@@ -1,6 +1,6 @@
 export interface MainPostingReportEntity {
   /**
-   * @pattern ^[1-9][0-9]{1,17}
+   * @pattern ^[1-9][0-9]{0,17}
    */
   id: string;
 
@@ -9,7 +9,7 @@ export interface MainPostingReportEntity {
   content: string;
 
   /**
-   * @pattern ^[1-9][0-9]{1,17}
+   * @pattern ^[1-9][0-9]{0,17}
    */
   mainPostingId: string;
 }

--- a/server/src/database/models/main-posting/main-posting.entity.ts
+++ b/server/src/database/models/main-posting/main-posting.entity.ts
@@ -3,7 +3,7 @@ import { CommonDateEntity } from '../common/common-date.entity';
 export namespace MainPostingEntity {
   export interface MainPosting extends CommonDateEntity {
     /**
-     * @pattern ^[1-9][0-9]{1,17}
+     * @pattern ^[1-9][0-9]{0,17}
      */
     id: string; // Max : 9223372036854775807
 

--- a/server/src/database/repositories/outbound-ports/main-posting-repository.outbound-port.ts
+++ b/server/src/database/repositories/outbound-ports/main-posting-repository.outbound-port.ts
@@ -1,6 +1,8 @@
 import { IsDeletedOutputDto } from 'src/database/dtos/common/crud-bool.dto';
 import {
   CreateMainPostingInputDto,
+  FindMainPostingListOptionsForPagenationDto,
+  FindMainPostingListOutputDto,
   FindMainPostingOptionsDto,
 } from 'src/database/dtos/main-posting/main-posting.outbound-port.dto';
 import { MainPostingEntity } from 'src/database/models/main-posting/main-posting.entity';
@@ -17,6 +19,10 @@ export interface MainPostingRepositoryOutboundPort {
   findMainPosting(
     options: FindMainPostingOptionsDto,
   ): Promise<MainPostingEntity.MainPosting | null>;
+
+  findMainPostings(
+    options: FindMainPostingListOptionsForPagenationDto,
+  ): Promise<FindMainPostingListOutputDto | null>;
 
   updateMainPosting(
     id: string,

--- a/server/src/domain/main-posting/main-posting.controller.ts
+++ b/server/src/domain/main-posting/main-posting.controller.ts
@@ -1,16 +1,47 @@
 import { Controller, UnauthorizedException, UseGuards } from '@nestjs/common';
 import { MainPostingService } from './main-posting.service';
-import { TypedBody, TypedParam, TypedRoute } from '@nestia/core';
+import { TypedBody, TypedParam, TypedQuery, TypedRoute } from '@nestia/core';
 import { JwtAdminGuard } from 'src/auth/guards/jwt-admin.guard';
 import { User } from 'src/common/decorators/user.decorator';
 import { AdminLogInDto } from 'src/database/dtos/auth/admin-login.dto';
-import { CreateMainPostingInputDto } from 'src/database/dtos/main-posting/main-posting.outbound-port.dto';
+import {
+  CreateMainPostingInputDto,
+  FindMainPostingListOptionsForPagenationDto,
+} from 'src/database/dtos/main-posting/main-posting.outbound-port.dto';
 import { IsDeletedOutputDto } from 'src/database/dtos/common/crud-bool.dto';
 import { MainPostingEntity } from 'src/database/models/main-posting/main-posting.entity';
+import { MainPostingPagenationQueryInputDto } from 'src/database/dtos/main-posting/main-posting.inbound-port.dto';
 
 @Controller('api/v1/main-posting')
 export class MainPostingController {
   constructor(private readonly mainPostingService: MainPostingService) {}
+
+  @TypedRoute.Get('list')
+  async getMainPostingList(
+    @TypedQuery() query: MainPostingPagenationQueryInputDto,
+  ) {
+    const input: FindMainPostingListOptionsForPagenationDto = {
+      countPerPage: query.countPerPage,
+      pageNumber: query.pageNumber,
+      options: {
+        adminId: query.adminId,
+        categoryId: query.categoryId,
+      },
+      order:
+        query.orderType && query.order
+          ? {
+              type: query.orderType,
+              order: query.order,
+            }
+          : undefined,
+    };
+
+    const mainPostings = await this.mainPostingService.getMainPostingList(
+      input,
+    );
+
+    return mainPostings;
+  }
 
   @UseGuards(JwtAdminGuard)
   @TypedRoute.Post()

--- a/server/src/domain/main-posting/main-posting.service.ts
+++ b/server/src/domain/main-posting/main-posting.service.ts
@@ -5,7 +5,11 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { IsDeletedOutputDto } from 'src/database/dtos/common/crud-bool.dto';
-import { CreateMainPostingInputDto } from 'src/database/dtos/main-posting/main-posting.outbound-port.dto';
+import {
+  CreateMainPostingInputDto,
+  FindMainPostingListOptionsForPagenationDto,
+  FindMainPostingListOutputDto,
+} from 'src/database/dtos/main-posting/main-posting.outbound-port.dto';
 import { MainPostingEntity } from 'src/database/models/main-posting/main-posting.entity';
 import {
   MAIN_POSTING_REPOSITORY_OUTBOUND_PORT,
@@ -33,6 +37,18 @@ export class MainPostingService {
     }
 
     return mainPosting;
+  }
+
+  async getMainPostingList(
+    options: FindMainPostingListOptionsForPagenationDto,
+  ): Promise<FindMainPostingListOutputDto> {
+    const mainPostings = await this.mainPostingRepo.findMainPostings(options);
+
+    if (!mainPostings) {
+      throw new BadRequestException('Incorrect option');
+    }
+
+    return mainPostings;
   }
 
   async modifyMainPosting(

--- a/server/src/test/unit/main-posting.spec.ts
+++ b/server/src/test/unit/main-posting.spec.ts
@@ -3,8 +3,12 @@ import { MockMainPostingRepository } from './mock/main-posting.repository.mock';
 import { MainPostingController } from 'src/domain/main-posting/main-posting.controller';
 import typia from 'typia';
 import { MainPostingEntity } from 'src/database/models/main-posting/main-posting.entity';
-import { CreateMainPostingInputDto } from 'src/database/dtos/main-posting/main-posting.outbound-port.dto';
+import {
+  CreateMainPostingInputDto,
+  FindMainPostingListOutputDto,
+} from 'src/database/dtos/main-posting/main-posting.outbound-port.dto';
 import { AdminLogInDto } from 'src/database/dtos/auth/admin-login.dto';
+import { MainPostingPagenationQueryInputDto } from 'src/database/dtos/main-posting/main-posting.inbound-port.dto';
 
 describe('MainPosting Spec', () => {
   describe('1. Create MainPosting', () => {
@@ -112,7 +116,25 @@ describe('MainPosting Spec', () => {
   });
 
   describe('5. Read MainPosting List', () => {
-    it.todo('5-1. 메인포스팅 목록을 불러옵니다.');
+    it('5-1. 메인포스팅 목록을 불러옵니다.', async () => {
+      const mainPostings = typia.random<FindMainPostingListOutputDto>();
+
+      const query = typia.random<MainPostingPagenationQueryInputDto>();
+
+      const mainPostingService = new MainPostingService(
+        new MockMainPostingRepository({
+          findMainPostings: [mainPostings],
+        }),
+      );
+
+      const mainPostingController = new MainPostingController(
+        mainPostingService,
+      );
+
+      const res = await mainPostingController.getMainPostingList(query);
+
+      expect(res).toStrictEqual(mainPostings);
+    });
   });
 
   describe('6. Read MainPosting and MainPosting Category for Main Page', () => {

--- a/server/src/test/unit/mock/main-posting.repository.mock.ts
+++ b/server/src/test/unit/mock/main-posting.repository.mock.ts
@@ -1,6 +1,8 @@
 import { IsDeletedOutputDto } from 'src/database/dtos/common/crud-bool.dto';
 import {
   CreateMainPostingInputDto,
+  FindMainPostingListOptionsForPagenationDto,
+  FindMainPostingListOutputDto,
   FindMainPostingOptionsDto,
 } from 'src/database/dtos/main-posting/main-posting.outbound-port.dto';
 import { MainPostingEntity } from 'src/database/models/main-posting/main-posting.entity';
@@ -43,6 +45,19 @@ export class MockMainPostingRepository
 
     return res;
   }
+
+  async findMainPostings(
+    options: FindMainPostingListOptionsForPagenationDto,
+  ): Promise<FindMainPostingListOutputDto | null> {
+    const res = await this.result.findMainPostings?.pop();
+
+    if (res === undefined) {
+      throw new Error('undefined');
+    }
+
+    return res;
+  }
+
   async updateMainPosting(
     id: string,
     data: CreateMainPostingInputDto,

--- a/server/src/utils/functions/date-and-bigint-to-string.function.ts
+++ b/server/src/utils/functions/date-and-bigint-to-string.function.ts
@@ -18,7 +18,12 @@ export function dateAndBigIntToString<T extends object>(
       }
 
       if (value instanceof Array) {
-        return { ...acc, [key]: value };
+        return {
+          ...acc,
+          [key]: value.map((el) => {
+            return dateAndBigIntToString(el);
+          }),
+        };
       }
 
       if (value instanceof Date) {


### PR DESCRIPTION
## 개요

- 메인 포스팅 리스트를 옵션에 따라 가져올 수 있다.
- 옵션은 countPerPage, typeOrder, order, pageNumber, adminId, categoryId 등이 있다.

## ✅ 작업 내용

- findMainPostings in MainPostingRepository
- getMainPostingList in MainPostingService
- getMainPostingList in MainPostingController
- mainPosting inbound dto
- read main posting list test

## 🔨 변경 로직

- typia comment `@pattern` of ids.
- Array branch in dateAndBigIntToString

## 🧨 관련 이슈

- #22 
