### PR TITLE
Feat : get main posting detail

### DIFF
--- a/server/src/database/prisma/prisma.service.ts
+++ b/server/src/database/prisma/prisma.service.ts
@@ -11,6 +11,21 @@ export class PrismaService extends PrismaClient implements OnModuleInit {
 
   async onModuleInit() {
     await this.$connect();
+
+    this.$use(async (params, next) => {
+      if (
+        params.action === 'findFirst' ||
+        params.action === 'findMany' ||
+        params.action === 'findRaw' ||
+        params.action === 'findUnique'
+      ) {
+        console.log(params.args);
+        params.args.where['deletedAt'] = null;
+        console.log(params.args);
+      }
+
+      return next(params);
+    });
   }
 
   async enableShutdownHooks(app: INestApplication) {

--- a/server/src/domain/main-posting/main-posting.controller.ts
+++ b/server/src/domain/main-posting/main-posting.controller.ts
@@ -43,6 +43,13 @@ export class MainPostingController {
     return mainPostings;
   }
 
+  @TypedRoute.Get(':id')
+  async getMainPosting(@TypedParam('id') id: string) {
+    const mainPosting = await this.mainPostingService.getMainPosting({ id });
+
+    return mainPosting;
+  }
+
   @UseGuards(JwtAdminGuard)
   @TypedRoute.Post()
   async createMainPosting(

--- a/server/src/domain/main-posting/main-posting.service.ts
+++ b/server/src/domain/main-posting/main-posting.service.ts
@@ -2,6 +2,7 @@ import {
   BadRequestException,
   Inject,
   Injectable,
+  NotFoundException,
   UnauthorizedException,
 } from '@nestjs/common';
 import { IsDeletedOutputDto } from 'src/database/dtos/common/crud-bool.dto';
@@ -46,7 +47,7 @@ export class MainPostingService {
     const mainPosting = await this.mainPostingRepo.findMainPosting(options);
 
     if (!mainPosting) {
-      throw new BadRequestException('incorrect option');
+      throw new NotFoundException('not found');
     }
 
     return mainPosting;

--- a/server/src/domain/main-posting/main-posting.service.ts
+++ b/server/src/domain/main-posting/main-posting.service.ts
@@ -9,6 +9,7 @@ import {
   CreateMainPostingInputDto,
   FindMainPostingListOptionsForPagenationDto,
   FindMainPostingListOutputDto,
+  FindMainPostingOptionsDto,
 } from 'src/database/dtos/main-posting/main-posting.outbound-port.dto';
 import { MainPostingEntity } from 'src/database/models/main-posting/main-posting.entity';
 import {
@@ -34,6 +35,18 @@ export class MainPostingService {
 
     if (!mainPosting) {
       throw new BadRequestException('Incorrect option');
+    }
+
+    return mainPosting;
+  }
+
+  async getMainPosting(
+    options: FindMainPostingOptionsDto,
+  ): Promise<MainPostingEntity.MainPosting> {
+    const mainPosting = await this.mainPostingRepo.findMainPosting(options);
+
+    if (!mainPosting) {
+      throw new BadRequestException('incorrect option');
     }
 
     return mainPosting;

--- a/server/src/test/unit/main-posting.spec.ts
+++ b/server/src/test/unit/main-posting.spec.ts
@@ -43,7 +43,23 @@ describe('MainPosting Spec', () => {
   });
 
   describe('2. Read MainPosting', () => {
-    it.todo('2-1. 메인포스팅을 상세 내용을 불러옵니다.');
+    it('2-1. 메인포스팅을 상세 내용을 불러옵니다.', async () => {
+      const mainPosting = typia.random<MainPostingEntity.MainPosting>();
+
+      const mainPostingService = new MainPostingService(
+        new MockMainPostingRepository({
+          findMainPosting: [mainPosting],
+        }),
+      );
+
+      const mainPostingController = new MainPostingController(
+        mainPostingService,
+      );
+
+      const res = await mainPostingController.getMainPosting(mainPosting.id);
+
+      expect(res).toStrictEqual(mainPosting);
+    });
   });
 
   describe('3. Update MainPosting', () => {


### PR DESCRIPTION
## 개요

- 메인 포스팅의 내용을 볼 수 있다.

## ✅ 작업 내용

- getMainPosting in MainPostingService
- getMainPosting in MainPostingController
- add middleware to prisma not to find softDeleted column
- read main posting

## 🔨 변경 로직

- NotFoundException getMainPosting in MainPostingService

## 🧨 관련 이슈

- #22 
